### PR TITLE
feat(otef-remote): redesign remote controller UX and polish layers + curation behavior

### DIFF
--- a/docs/superpowers/mockups/README.md
+++ b/docs/superpowers/mockups/README.md
@@ -5,6 +5,10 @@
 | File | Role |
 |------|------|
 | `otef-remote-mockup.html` | One page: **Navigation** (single phone), **Layers** (wider block with **two** adjacent phone shells — pack overview + focused pack), **Workshop** (single phone). Frames sit side-by-side when the viewport is wide and wrap on narrow screens. |
+| `otef-remote-layers-mockups.html` | **Hub** that embeds the chosen **Layers** mockup (**Variant C**) in one iframe; intro links to the UX follow-up plan. Open from the `mockups/` folder so sibling relative paths resolve. |
+| `otef-remote-layers-variant-c.html` | **Variant C (chosen)** — **Sharpened** static comp: horizontal **pack strip** (edge fades, **no** visible scrollbar), **responsive layer tile grid**, **one bulk visibility toggle**, tile-level **animation** control, **per-pack + header counts**, **RTL + LTR** shells. Exploratory variants **A** and **B** were removed after selection. |
+
+**Layers shell follow-up (2026-04-22):** UX follow-up plan: [`../plans/2026-04-22-otef-remote-ux-followup.md`](../plans/2026-04-22-otef-remote-ux-followup.md) (Variant **C** + hub above).
 
 ## What each screen demonstrates
 

--- a/docs/superpowers/mockups/README.md
+++ b/docs/superpowers/mockups/README.md
@@ -1,0 +1,39 @@
+# OTEF Remote — Task 2 visual mockups
+
+**Purpose:** Reviewable, static-only artifacts for the 2026-04-22 remote redesign plan (Task 2: Navigation / Layers / Workshop), aligned with `otef-interactive/frontend/DESIGN.md`. No app wiring; open in a browser.
+
+| File | Role |
+|------|------|
+| `otef-remote-mockup.html` | One page: **Navigation** (single phone), **Layers** (wider block with **two** adjacent phone shells — pack overview + focused pack), **Workshop** (single phone). Frames sit side-by-side when the viewport is wide and wrap on narrow screens. |
+
+## What each screen demonstrates
+
+1. **Navigation** — Terracotta/Negev shell: compact header (title, **Hebrew | EN** locale toggle) and a **connection lamp only** (green dot; red reserved for offline — see *Grounding*). **Map/table context is a thin sliver; the primary content is the D-pad, joystick, and zoom block** (same family of controls as the current main remote controller), scaled for one hand. **No layer UI** here. **Table switcher is not shown in these mockups** (implementation still uses `#table-switcher` in the app — omitted here for visual focus).
+
+2. **Layers (two phones)** — Same **compact header** as other tabs (lamp + locale). Represented as **two static states next to each other** (no JS):
+   - **Task 6 / behavior:** **Overview → focused-pack drill-in** is the UX equivalent of the prior in-list **group expand/collapse** (same grouping/toggles/actions; only the navigation shell changes).
+   - **Overview phone:** **All packs at a glance** — compact tiles; this iteration stresses **no endless single-column scroll of every layer** (overview + focused states). If tiles exceed the viewport, **bounded scroll inside the Layers panel** is expected — do not read the comp as “never scroll.” Each tile shows **how many layers are active in that pack** (illustrative counts), a **pack master** on/off toggle, and a **separate open/drill** control (not the same action as master).
+   - **Focused phone:** Full **single-pack** view after “opening” a pack (example: **זרימה**). **Back** affordance to return to the overview list. **Pack-level Flow** (for flow packs) stays in the **header**; rows show **visibility** toggles and **per-row animation** only where applicable — **non-flow** focused packs are **visibility-only** (no Flow header cluster, no animation column). Example rows show **mixed** animation (one on, one off). **No** noisy מעובד / אוצרות / raw **id** badges; a small **flow-category** indicator (e.g. זרם) is allowed when it clarifies the row. Merged / multi-id semantics stay in **short, human copy** when useful.
+
+3. **Workshop (סדנה)** — Renamed from “Curation”; **English** tab label: **workshop** (EN toggle / mirrored layout). **Same** functional intent as today: same-origin `curation.html?embed=1` surface, **parent** owns Supabase/heartbeat, embedded document **no extra logic**. The frame is **visually refreshed** (intro copy, chips) but does **not** claim new product capabilities.
+
+## Grounding (from layer-scheme / runtime analysis — documentation only)
+
+- **Packs** reflect **effective layer groups in runtime**; they are not a fixed list in this file.
+- **Curated** paths can add **special merge / handling**; treat those as “same data model, different rules,” not a second product.
+- **One row** can map to **multiple full layer ids**; counts and master toggles may aggregate accordingly.
+- **Animation** toggles are **not** the same as **visibility** toggles (when a layer has animation at all).
+- **Connection UI** in the mockup is intentionally minimal: a **lamp** only (green = connected; for offline, use a red treatment — CSS hook `status-pip.is-off` exists for future static comps).
+- **Table switcher** is **hidden in mockups**; the implementation contract in `remote-controller` / `table-switcher.js` is unchanged in code and should stay documented in the main plan, not in this file.
+
+## Implementation targets (mockup vs. app)
+
+- **Bottom tabs:** `DESIGN.md` lists `spacing.touch` **56px** as the primary hit target. The mockup uses `min-height` / `min-width: 56px` on tab buttons (bar can stay ~64px tall per token). If production differs slightly, keep **≥44px** minimum accessible target and prefer **56px** where layout allows.
+
+## Task 2 plan checklist (mapping)
+
+- **2.1** — Three frame groups: **Navigation** (controller-first, no layers, no table switcher in comp), **Layers** (dual-phone: overview + focused), **Workshop** (embed surface). **Consistent** compact header; Hebrew default. **Curation** naming retired in the mockup; **workshop** / **סדנה** used in labels and README.
+- **2.2** — Layers: **pack master** separate from **open/drill**; **pack-level Flow** on focused flow packs vs **per-row** animation (conditional — omit for non-flow packs); **mixed** row animation example; **active counts** on overview tiles + global total in title row; **no** noisy processed/אוצרות/id badges; **flow-category** chip OK when relevant; mobile-first Negev styling.
+- **2.3** — Navigation and Workshop show **layout / chrome / one-hand** intent without matching Layers density.
+
+**Review:** Open `otef-remote-mockup.html` locally, narrow or zoom the window to approximate phone width, and compare to `docs/superpowers/plans/2026-04-22-otef-remote-redesign.md` STOP GATE.

--- a/docs/superpowers/mockups/otef-remote-layers-mockups.html
+++ b/docs/superpowers/mockups/otef-remote-layers-mockups.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>מוקאפ שכבות — וריאנט C (נבחר)</title>
+    <style>
+      :root {
+        --color-primary: #c17f4a;
+        --color-canvas: #12100e;
+        --color-surface: #1c1917;
+        --color-surface-raised: #262320;
+        --color-ink: #f5f0ea;
+        --color-ink-muted: #bfb6ab;
+        --color-ink-subtle: #8c847a;
+        --color-border: #3d3834;
+        --r-md: 12px;
+        --r-pill: 9999px;
+        --space-sm: 12px;
+        --space-md: 16px;
+        --space-lg: 24px;
+        --font-ui: system-ui, "Segoe UI", "SF Pro Text", "Helvetica Neue", "Noto Sans Hebrew", sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: var(--space-lg) var(--space-md) calc(var(--space-lg) * 2);
+        background: var(--color-canvas);
+        color: var(--color-ink-muted);
+        font-family: var(--font-ui);
+        line-height: 1.6;
+      }
+      .wrap {
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+      h1 {
+        color: var(--color-ink);
+        font-size: 1.35rem;
+        font-weight: 600;
+        margin: 0 0 0.75rem;
+        letter-spacing: -0.02em;
+      }
+      .intro {
+        font-size: 0.9rem;
+        color: var(--color-ink-subtle);
+        margin: 0 0 var(--space-md);
+        max-width: 52rem;
+      }
+      .intro a {
+        color: var(--color-primary);
+        text-decoration: none;
+        border-bottom: 1px solid rgba(193, 127, 74, 0.45);
+      }
+      .intro a:hover {
+        color: var(--color-ink);
+        border-bottom-color: var(--color-ink);
+      }
+      section {
+        margin-bottom: var(--space-lg);
+      }
+      section h2 {
+        color: var(--color-ink);
+        font-size: 1.05rem;
+        font-weight: 600;
+        margin: 0 0 10px;
+        padding-bottom: 6px;
+        border-bottom: 1px solid var(--color-border);
+      }
+      .frame {
+        width: 100%;
+        min-height: 1580px;
+        border: 1px solid var(--color-border);
+        border-radius: var(--r-md);
+        background: #0a0908;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>מוקאפ שכבות — וריאנט C (נבחר ומחודד)</h1>
+      <p class="intro">
+        עמוד זה מטמיע את
+        <code>otef-remote-layers-variant-c.html</code>
+        — המוקאפ הסטטי שעליו מבוססים מימוש הלשונית &quot;שכבות&quot;. אין JavaScript. תכנית המשך:
+        <a href="../plans/2026-04-22-otef-remote-ux-followup.md">2026-04-22-otef-remote-ux-followup.md</a>.
+        ניתן לפתוח גם את קובץ ה־HTML של הוריאנט ישירות מאותה תיקייה.
+      </p>
+      <section id="variant-c" aria-labelledby="t-c">
+        <h2 id="t-c">וריאנט C — בורר חבילות + אריחי שכבות (RTL + LTR)</h2>
+        <iframe
+          class="frame"
+          src="otef-remote-layers-variant-c.html"
+          title="מוקאפ שכבות — וריאנט C"
+        ></iframe>
+      </section>
+    </div>
+  </body>
+</html>

--- a/docs/superpowers/mockups/otef-remote-layers-variant-c.html
+++ b/docs/superpowers/mockups/otef-remote-layers-variant-c.html
@@ -1,0 +1,813 @@
+<!DOCTYPE html>
+<html lang="he">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>שכבות — וריאנט C (מחודד): קרוסלת חבילות + רשת אריחי שכבות</title>
+    <style>
+      :root {
+        /* Tokens aligned with otef-remote-mockup.html */
+        --color-primary: #c17f4a;
+        --color-canvas: #12100e;
+        --color-surface: #1c1917;
+        --color-surface-raised: #262320;
+        --color-ink: #f5f0ea;
+        --color-ink-muted: #bfb6ab;
+        --color-ink-subtle: #8c847a;
+        --color-on-primary: #141210;
+        --color-border: #3d3834;
+        --color-border-strong: #4a4540;
+        --color-success: #7a9b7a;
+        --r-sm: 8px;
+        --r-md: 12px;
+        --r-pill: 9999px;
+        --space-xs: 8px;
+        --space-sm: 12px;
+        --space-md: 16px;
+        --header-safe: max(12px, env(safe-area-inset-top, 0px));
+        --font-ui: system-ui, "Segoe UI", "SF Pro Text", "Helvetica Neue", "Noto Sans Hebrew", sans-serif;
+        --shadow-soft: 0 8px 24px rgba(10, 8, 6, 0.35);
+        --focus-ring: 2px solid rgba(193, 127, 74, 0.85);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        padding: var(--space-md);
+        background: var(--color-canvas);
+        color: var(--color-ink-muted);
+        font-family: var(--font-ui);
+        line-height: 1.5;
+      }
+      .page-hint {
+        max-width: 520px;
+        margin: 0 auto var(--space-md);
+        font-size: 0.76rem;
+        color: var(--color-ink-muted);
+        text-align: center;
+      }
+      .phones {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--space-md);
+        margin-bottom: var(--space-sm);
+      }
+      .phone-label {
+        width: 100%;
+        max-width: 360px;
+        margin: 0 auto;
+        font-size: 0.65rem;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-ink-subtle);
+        padding-inline: 4px;
+      }
+      .phone {
+        max-width: 360px;
+        margin: 0 auto;
+        border-radius: 28px;
+        padding: 10px;
+        background: linear-gradient(145deg, #2a2622, #1a1816);
+        box-shadow: var(--shadow-soft);
+      }
+      .phone-notch {
+        height: 24px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 4px;
+      }
+      .phone-notch::before {
+        content: "";
+        width: 96px;
+        height: 22px;
+        background: #0a0908;
+        border-radius: 12px;
+      }
+      .screen {
+        border-radius: 20px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        min-height: 620px;
+        max-height: 760px;
+        background: var(--color-canvas);
+        border: 1px solid var(--color-border);
+      }
+      .screen[dir="rtl"] {
+        direction: rtl;
+      }
+      .screen[dir="ltr"] {
+        direction: ltr;
+      }
+      .app-header {
+        background: var(--color-surface);
+        padding: calc(10px + var(--header-safe)) var(--space-md) var(--space-sm);
+        border-bottom: 1px solid var(--color-border);
+        flex-shrink: 0;
+      }
+      .app-header-top {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--space-sm);
+      }
+      .app-header__title-block {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 2px;
+        min-width: 0;
+      }
+      .app-header__layer-total {
+        font-size: 0.6rem;
+        font-weight: 500;
+        color: var(--color-ink-subtle);
+        line-height: 1.2;
+        letter-spacing: 0.02em;
+      }
+      .header-end {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex-shrink: 0;
+      }
+      .app-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--color-ink);
+        margin: 0;
+      }
+      .status-pip .connection-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--color-success);
+        box-shadow: 0 0 0 2px rgba(122, 155, 122, 0.35);
+      }
+      .locale-toggle {
+        display: inline-flex;
+        border: 1px solid var(--color-border);
+        border-radius: var(--r-md);
+        overflow: hidden;
+        font-size: 0.75rem;
+        font-weight: 500;
+      }
+      .locale-toggle button {
+        border: none;
+        padding: 8px 10px;
+        min-height: 44px;
+        min-width: 44px;
+        background: var(--color-surface-raised);
+        color: var(--color-ink-muted);
+        cursor: default;
+        font: inherit;
+      }
+      .locale-toggle button.active {
+        background: var(--color-primary);
+        color: var(--color-on-primary);
+      }
+      .pack-strip-wrap {
+        padding-block-start: var(--space-xs);
+        padding-inline: var(--space-sm);
+        padding-block-end: 4px;
+        border-bottom: 1px solid var(--color-border);
+        background: var(--color-canvas);
+        flex-shrink: 0;
+      }
+      .pack-strip-wrap__head {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 8px;
+        margin-block-end: 6px;
+        margin-inline: 2px;
+      }
+      .pack-strip-wrap__label {
+        font-size: 0.59rem;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: var(--color-ink-muted);
+        margin: 0;
+      }
+      .pack-strip-wrap__pack-count {
+        font-size: 0.6rem;
+        font-weight: 600;
+        color: var(--color-ink-subtle);
+        white-space: nowrap;
+      }
+      .pack-strip {
+        display: block;
+      }
+      .pack-strip__viewport {
+        position: relative;
+        margin-inline: -4px;
+        padding-inline: 4px;
+        overflow: hidden;
+      }
+      .pack-strip__edge {
+        position: absolute;
+        inset-block: 0;
+        width: 22px;
+        z-index: 1;
+        pointer-events: none;
+      }
+      .pack-strip__edge--start {
+        inset-inline-start: 0;
+      }
+      .pack-strip__edge--end {
+        inset-inline-end: 0;
+      }
+      .screen[dir="ltr"] .pack-strip__edge--start {
+        background: linear-gradient(90deg, var(--color-canvas) 0%, rgba(18, 16, 14, 0) 100%);
+      }
+      .screen[dir="ltr"] .pack-strip__edge--end {
+        background: linear-gradient(270deg, var(--color-canvas) 0%, rgba(18, 16, 14, 0) 100%);
+      }
+      .screen[dir="rtl"] .pack-strip__edge--start {
+        background: linear-gradient(270deg, var(--color-canvas) 0%, rgba(18, 16, 14, 0) 100%);
+      }
+      .screen[dir="rtl"] .pack-strip__edge--end {
+        background: linear-gradient(90deg, var(--color-canvas) 0%, rgba(18, 16, 14, 0) 100%);
+      }
+      .pack-strip__scroller {
+        display: flex;
+        min-width: 0;
+        overflow-x: auto;
+        overflow-y: hidden;
+        gap: 8px;
+        padding-block-start: 4px;
+        padding-inline-end: 12px;
+        padding-block-end: 8px;
+        padding-inline-start: 6px;
+        scroll-snap-type: x mandatory;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+      }
+      .pack-strip__scroller::-webkit-scrollbar {
+        display: none;
+      }
+      .pack-strip__hint {
+        margin-block-start: 0;
+        margin-inline: 2px;
+        margin-block-end: 2px;
+        font-size: 0.62rem;
+        color: var(--color-ink-muted);
+        letter-spacing: 0.03em;
+        text-align: center;
+        line-height: 1.3;
+      }
+      .pack-chip {
+        flex: 0 0 auto;
+        scroll-snap-align: start;
+        padding: 8px 14px;
+        border-radius: var(--r-pill);
+        border: 1px solid var(--color-border-strong);
+        background: var(--color-surface-raised);
+        color: var(--color-ink-muted);
+        font-size: 0.78rem;
+        font-weight: 600;
+        white-space: nowrap;
+        cursor: default;
+        font: inherit;
+        line-height: 1.25;
+      }
+      .pack-chip--selected {
+        background: var(--color-primary);
+        color: var(--color-on-primary);
+        border-color: var(--color-primary);
+        box-shadow: 0 0 0 1px rgba(193, 127, 74, 0.4);
+      }
+      .bulk-visibility {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px 12px;
+        padding: 8px var(--space-sm) 10px;
+        border-bottom: 1px solid var(--color-border);
+        background: var(--color-canvas);
+        flex-shrink: 0;
+        margin-bottom: 12px;
+      }
+      .bulk-visibility__micro {
+        font-size: 0.59rem;
+        color: var(--color-ink-muted);
+        letter-spacing: 0.04em;
+        flex: 0 0 auto;
+      }
+      .bulk-visibility__pack-toggle {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 10px;
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .bulk-visibility__state-label {
+        font-size: 0.7rem;
+        font-weight: 600;
+        color: var(--color-ink);
+        line-height: 1.2;
+        text-align: start;
+        max-width: 60%;
+      }
+      .bulk-visibility__microcopy {
+        flex: 0 0 100%;
+        margin: 0;
+        font-size: 0.62rem;
+        line-height: 1.3;
+        color: var(--color-ink-muted);
+        text-align: start;
+        padding-inline: 1px 2px;
+        margin-block-start: 2px;
+      }
+      .bulk-toggle {
+        position: relative;
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        padding: 0;
+        border: none;
+        background: none;
+        cursor: default;
+        font: inherit;
+        min-width: 52px;
+        min-height: 44px;
+        justify-content: center;
+        padding-inline: 6px;
+      }
+      .bulk-toggle__track {
+        position: relative;
+        display: block;
+        width: 48px;
+        height: 28px;
+        border-radius: 9999px;
+        background: var(--color-surface-raised);
+        box-shadow: inset 0 0 0 1px var(--color-border-strong);
+        transition: background 0.15s;
+      }
+      .bulk-toggle.is-pressed .bulk-toggle__track {
+        background: rgba(122, 155, 122, 0.28);
+        box-shadow: inset 0 0 0 1px rgba(122, 155, 122, 0.55);
+      }
+      .bulk-toggle__thumb {
+        position: absolute;
+        top: 3px;
+        inset-inline-start: 3px;
+        inset-inline-end: auto;
+        width: 22px;
+        height: 22px;
+        border-radius: 50%;
+        background: var(--color-ink-muted);
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+        transition: background 0.15s;
+      }
+      .bulk-toggle.is-pressed .bulk-toggle__thumb {
+        inset-inline-start: auto;
+        inset-inline-end: 3px;
+        background: var(--color-ink);
+      }
+      .grid-head {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        padding: 6px 12px 6px;
+        gap: 8px;
+        flex-shrink: 0;
+      }
+      .grid-head h2 {
+        margin: 0;
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: var(--color-ink);
+      }
+      .grid-head span {
+        font-size: 0.65rem;
+        color: var(--color-ink-subtle);
+        white-space: nowrap;
+      }
+      .layer-selection-legend {
+        margin: 0;
+        padding: 0 12px 8px;
+        font-size: 0.6rem;
+        line-height: 1.4;
+        color: var(--color-ink-subtle);
+        border-bottom: 1px solid var(--color-border);
+        flex-shrink: 0;
+      }
+      .app-main {
+        flex: 1;
+        min-height: 0;
+        overflow: auto;
+        padding: 6px 10px 14px;
+        -webkit-overflow-scrolling: touch;
+      }
+      .layer-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(148px, 1fr));
+        gap: 8px;
+      }
+      .layer-tile {
+        position: relative;
+        display: flex;
+        align-items: flex-start;
+        min-height: 64px;
+        padding-block-start: 6px;
+        padding-inline-end: 50px;
+        padding-block-end: 50px;
+        padding-inline-start: 8px;
+        background: var(--color-surface-raised);
+        border-radius: var(--r-sm);
+        border: 1px dashed var(--color-ink-subtle);
+        color: var(--color-ink-subtle);
+        font-size: 0.78rem;
+        font-weight: 600;
+        line-height: 1.25;
+        text-align: start;
+        cursor: default;
+        outline: none;
+        opacity: 0.58;
+      }
+      .layer-tile.is-visible,
+      .layer-tile.is-active {
+        opacity: 1;
+        color: var(--color-ink);
+      }
+      .layer-tile.is-active {
+        border-style: solid;
+        border-color: var(--color-primary);
+        box-shadow: 0 0 0 2px rgba(193, 127, 74, 0.45);
+        background: rgba(193, 127, 74, 0.16);
+      }
+      .layer-tile.is-visible:not(.is-active) {
+        border-style: solid;
+        border-color: rgba(122, 155, 122, 0.65);
+        box-shadow: 0 0 0 1px rgba(122, 155, 122, 0.35);
+        background: rgba(122, 155, 122, 0.09);
+        color: var(--color-ink);
+      }
+      .layer-tile:not(.is-visible):not(.is-active) {
+        color: var(--color-ink-subtle);
+      }
+      .layer-tile:not(:has(.anim-btn:not(.anim-btn--absent))) {
+        align-items: center;
+        min-height: 48px;
+        padding-block-start: 8px;
+        padding-inline-end: 10px;
+        padding-block-end: 10px;
+        padding-inline-start: 8px;
+      }
+      .layer-tile:focus-visible {
+        outline: var(--focus-ring);
+        outline-offset: 2px;
+      }
+      .layer-tile__name {
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+      .anim-btn {
+        position: absolute;
+        bottom: 6px;
+        inset-inline-end: 6px;
+        top: auto;
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+        border-radius: 10px;
+        border: 1px solid var(--color-border-strong);
+        background: var(--color-surface);
+        color: var(--color-ink-subtle);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: default;
+        font: inherit;
+        padding: 0;
+        line-height: 1;
+        box-sizing: border-box;
+        margin: 0;
+      }
+      .anim-btn::before {
+        content: "▶";
+        font-size: 0.6rem;
+        opacity: 0.65;
+      }
+      .anim-btn.is-on {
+        border-color: rgba(193, 127, 74, 0.65);
+        background: rgba(193, 127, 74, 0.2);
+        color: var(--color-primary);
+      }
+      .anim-btn.is-on::before {
+        opacity: 1;
+      }
+      .anim-btn--absent {
+        display: none;
+      }
+      .footnote {
+        max-width: 520px;
+        margin: var(--space-md) auto 0;
+        padding: var(--space-sm);
+        font-size: 0.7rem;
+        color: var(--color-ink-subtle);
+        border-top: 1px solid var(--color-border);
+        line-height: 1.45;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <p class="page-hint">
+      וריאנט C (מחודד) — מסלול חבילות אופקי ללא פס גלילה/חצים; קצוות־החשכה, רמז “גלילה אופקית” / Swipe, רשת אריחים,
+      מצב הסתר/הצגה מרוכז = מתג יחיד, אנימציה בפינה תחתית־הקצה. ללא JavaScript.
+    </p>
+
+    <div class="phones">
+      <p class="phone-label" lang="he">עברית — RTL</p>
+      <div class="phone">
+        <div class="phone-notch" aria-hidden="true"></div>
+        <div class="screen" lang="he" dir="rtl">
+          <header class="app-header">
+            <div class="app-header-top">
+              <div class="app-header__title-block">
+                <h1 class="app-title">שכבות</h1>
+                <p class="app-header__layer-total" lang="he">12 שכבות פעילות</p>
+              </div>
+              <div class="header-end">
+                <span class="status-pip"><span class="connection-dot" aria-hidden="true"></span></span>
+                <div class="locale-toggle" role="group" aria-label="שפה">
+                  <button type="button" class="active" disabled>עב</button>
+                  <button type="button" disabled>en</button>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <div class="pack-strip-wrap" role="region" aria-label="בחירת חבילת שכבות">
+            <div class="pack-strip-wrap__head">
+              <p class="pack-strip-wrap__label">חבילה</p>
+              <span class="pack-strip-wrap__pack-count" lang="he">4/7 פעילות</span>
+            </div>
+            <div class="pack-strip">
+              <div class="pack-strip__viewport">
+                <div class="pack-strip__edge pack-strip__edge--start" aria-hidden="true"></div>
+                <div class="pack-strip__edge pack-strip__edge--end" aria-hidden="true"></div>
+                <div class="pack-strip__scroller">
+                  <button type="button" class="pack-chip" disabled>הפניה מהירה</button>
+                  <button type="button" class="pack-chip" disabled>שטח פעולה</button>
+                  <button type="button" class="pack-chip pack-chip--selected" disabled>אוצרות</button>
+                  <button type="button" class="pack-chip" disabled>מקרן בסיס</button>
+                  <button type="button" class="pack-chip" disabled>7 באוקטובר</button>
+                </div>
+              </div>
+            </div>
+            <p class="pack-strip__hint" lang="he">גלילה אופקית · <span dir="ltr" lang="en">Swipe horizontally</span></p>
+          </div>
+
+          <div class="bulk-visibility" aria-label="הצגה או הסתרה מרוכזת לכל שכבות החבילה">
+            <span class="bulk-visibility__micro" lang="he">בחבילה זו</span>
+            <div class="bulk-visibility__pack-toggle">
+              <span class="bulk-visibility__state-label" id="he-bulk-lbl" lang="he">כל השכבות בחבילה מוצגות</span>
+              <button
+                type="button"
+                class="bulk-toggle is-pressed"
+                aria-pressed="true"
+                disabled
+                aria-labelledby="he-bulk-lbl he-bulk-hint"
+                title="הקש לכיבוי כל השכבות"
+              >
+                <span class="bulk-toggle__track" aria-hidden="true">
+                  <span class="bulk-toggle__thumb"></span>
+                </span>
+              </button>
+            </div>
+            <p class="bulk-visibility__microcopy" id="he-bulk-hint" lang="he">מתג בודד · אנימציה בפינת האריח.</p>
+          </div>
+
+          <div class="grid-head">
+            <h2>שכבות — אוצרות</h2>
+            <span lang="he">רשת שכבות בחבילה</span>
+          </div>
+          <p class="layer-selection-legend" lang="he">
+            <strong>נבחר (ראשי):</strong> מסגרת חומה (אריח אחד) · <strong>מוצג במפה:</strong> מסגרת ירוקה — לשכבות
+            נוספות שאינן הנבחר
+          </p>
+
+          <main class="app-main" aria-label="רשת שכבות לחבילה הנבחרת">
+            <div class="layer-grid">
+              <div
+                class="layer-tile is-active is-visible"
+                tabindex="0"
+                aria-label="יישובים — שכבה נבחרת (מוצגת במפה)"
+              >
+                <span class="layer-tile__name">יישובים</span>
+                <button
+                  type="button"
+                  class="anim-btn is-on"
+                  tabindex="-1"
+                  title="אנימציה: פועלת"
+                  aria-label="אנימציה פועלת"
+                  disabled
+                ></button>
+              </div>
+              <div class="layer-tile" tabindex="0" aria-label="גבולות מנהליים">
+                <span class="layer-tile__name">גבולות מנהליים</span>
+                <button
+                  type="button"
+                  class="anim-btn"
+                  tabindex="-1"
+                  title="אנימציה: כבויה"
+                  aria-label="אנימציה כבויה"
+                  disabled
+                ></button>
+              </div>
+              <div class="layer-tile is-visible" tabindex="0" aria-label="שטחי אימון — מוצג במפה">
+                <span class="layer-tile__name">שטחי אימון</span>
+                <span class="anim-btn anim-btn--absent" aria-hidden="true"></span>
+              </div>
+              <div class="layer-tile is-visible" tabindex="0" aria-label="מסלולי טיסה — מוצג במפה">
+                <span class="layer-tile__name">מסלולי טיסה</span>
+                <button
+                  type="button"
+                  class="anim-btn is-on"
+                  tabindex="-1"
+                  title="אנימציה: פועלת"
+                  aria-label="אנימציה פועלת"
+                  disabled
+                ></button>
+              </div>
+              <div class="layer-tile" tabindex="0" aria-label="נקודות עניין">
+                <span class="layer-tile__name">נקודות עניין</span>
+                <span class="anim-btn anim-btn--absent" aria-hidden="true"></span>
+              </div>
+              <div class="layer-tile" tabindex="0" aria-label="תצ״א">
+                <span class="layer-tile__name">תצ״א</span>
+                <button
+                  type="button"
+                  class="anim-btn"
+                  tabindex="-1"
+                  title="אנימציה: כבויה"
+                  aria-label="אנימציה כבויה"
+                  disabled
+                ></button>
+              </div>
+              <div class="layer-tile is-visible" tabindex="0" aria-label="תשתיות — מוצג במפה">
+                <span class="layer-tile__name">תשתיות</span>
+                <span class="anim-btn anim-btn--absent" aria-hidden="true"></span>
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+
+      <p class="phone-label" lang="en">English — LTR mirror</p>
+      <div class="phone">
+        <div class="phone-notch" aria-hidden="true"></div>
+        <div class="screen" lang="en" dir="ltr">
+          <header class="app-header">
+            <div class="app-header-top">
+              <div class="app-header__title-block">
+                <h1 class="app-title">Layers</h1>
+                <p class="app-header__layer-total" lang="en">12 layers on</p>
+              </div>
+              <div class="header-end">
+                <span class="status-pip"><span class="connection-dot" aria-hidden="true"></span></span>
+                <div class="locale-toggle" role="group" aria-label="Language">
+                  <button type="button" disabled>HE</button>
+                  <button type="button" class="active" disabled>EN</button>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <div class="pack-strip-wrap" role="region" aria-label="Layer pack picker">
+            <div class="pack-strip-wrap__head">
+              <p class="pack-strip-wrap__label">Pack</p>
+              <span class="pack-strip-wrap__pack-count" lang="en">4/7 active</span>
+            </div>
+            <div class="pack-strip">
+              <div class="pack-strip__viewport">
+                <div class="pack-strip__edge pack-strip__edge--start" aria-hidden="true"></div>
+                <div class="pack-strip__edge pack-strip__edge--end" aria-hidden="true"></div>
+                <div class="pack-strip__scroller">
+                  <button type="button" class="pack-chip" disabled>Quick ref</button>
+                  <button type="button" class="pack-chip" disabled>Field ops</button>
+                  <button type="button" class="pack-chip pack-chip--selected" disabled>Treasures</button>
+                  <button type="button" class="pack-chip" disabled>Base projector</button>
+                  <button type="button" class="pack-chip" disabled>October 7</button>
+                </div>
+              </div>
+            </div>
+            <p class="pack-strip__hint" lang="en">Swipe horizontally · <span dir="rtl" lang="he">גלילה אופקית</span></p>
+          </div>
+
+          <div class="bulk-visibility" aria-label="Show or hide all layers in the pack (single control)">
+            <span class="bulk-visibility__micro" lang="en">In this pack</span>
+            <div class="bulk-visibility__pack-toggle">
+              <span class="bulk-visibility__state-label" id="en-bulk-lbl" lang="en">All pack layers on</span>
+              <button
+                type="button"
+                class="bulk-toggle is-pressed"
+                aria-pressed="true"
+                disabled
+                aria-labelledby="en-bulk-lbl en-bulk-hint"
+                title="Tap to hide all layers in this pack"
+              >
+                <span class="bulk-toggle__track" aria-hidden="true">
+                  <span class="bulk-toggle__thumb"></span>
+                </span>
+              </button>
+            </div>
+            <p class="bulk-visibility__microcopy" id="en-bulk-hint" lang="en">Single toggle · animation on tile.</p>
+          </div>
+
+          <div class="grid-head">
+            <h2>Layers — Treasures</h2>
+            <span lang="en">Layer grid in this pack</span>
+          </div>
+          <p class="layer-selection-legend" lang="en">
+            <strong>Selected (primary):</strong> amber frame · <strong>On map:</strong> green frame (non-primary
+            only)
+          </p>
+
+          <main class="app-main" aria-label="Layer tiles for selected pack">
+            <div class="layer-grid">
+              <div
+                class="layer-tile is-active is-visible"
+                tabindex="0"
+                aria-label="Settlements — selected layer, visible on map"
+              >
+                <span class="layer-tile__name">Settlements</span>
+                <button
+                  type="button"
+                  class="anim-btn is-on"
+                  tabindex="-1"
+                  title="Animation: on"
+                  aria-label="Animation on"
+                  disabled
+                ></button>
+              </div>
+              <div class="layer-tile" tabindex="0" aria-label="Administrative boundaries">
+                <span class="layer-tile__name">Administrative boundaries</span>
+                <button
+                  type="button"
+                  class="anim-btn"
+                  tabindex="-1"
+                  title="Animation: off"
+                  aria-label="Animation off"
+                  disabled
+                ></button>
+              </div>
+              <div class="layer-tile is-visible" tabindex="0" aria-label="Training areas — visible on map">
+                <span class="layer-tile__name">Training areas</span>
+                <span class="anim-btn anim-btn--absent" aria-hidden="true"></span>
+              </div>
+              <div class="layer-tile is-visible" tabindex="0" aria-label="Flight paths — visible on map">
+                <span class="layer-tile__name">Flight paths</span>
+                <button
+                  type="button"
+                  class="anim-btn is-on"
+                  tabindex="-1"
+                  title="Animation: on"
+                  aria-label="Animation on"
+                  disabled
+                ></button>
+              </div>
+              <div class="layer-tile" tabindex="0" aria-label="Points of interest">
+                <span class="layer-tile__name">Points of interest</span>
+                <span class="anim-btn anim-btn--absent" aria-hidden="true"></span>
+              </div>
+              <div class="layer-tile" tabindex="0" aria-label="Aerial photo (TSA)">
+                <span class="layer-tile__name">Aerial imagery</span>
+                <button
+                  type="button"
+                  class="anim-btn"
+                  tabindex="-1"
+                  title="Animation: off"
+                  aria-label="Animation off"
+                  disabled
+                ></button>
+              </div>
+              <div class="layer-tile is-visible" tabindex="0" aria-label="Infrastructure — visible on map">
+                <span class="layer-tile__name">Infrastructure</span>
+                <span class="anim-btn anim-btn--absent" aria-hidden="true"></span>
+              </div>
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+
+    <p class="footnote" lang="en">
+      <strong>Engineering:</strong> pack id <code>curated</code> · e.g. <code>otef-interactive/public/processed/snapshot.json</code> (<code>public/processed</code> may be gitignored) · static mockup, no JavaScript.
+    </p>
+  </body>
+</html>

--- a/docs/superpowers/mockups/otef-remote-mockup.html
+++ b/docs/superpowers/mockups/otef-remote-mockup.html
@@ -1,0 +1,1428 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OTEF Remote — Task 2 mockups (static): Navigation / Layers (dual) / Workshop</title>
+    <style>
+      /* Tokens derived from otef-interactive/frontend/DESIGN.md (machine YAML + prose) */
+      :root {
+        --color-primary: #c17f4a;
+        --color-canvas: #12100e;
+        --color-surface: #1c1917;
+        --color-surface-raised: #262320;
+        --color-ink: #f5f0ea;
+        --color-ink-muted: #bfb6ab;
+        --color-ink-subtle: #8c847a;
+        --color-on-primary: #141210;
+        --color-border: #3d3834;
+        --color-border-strong: #4a4540;
+        --color-success: #7a9b7a;
+        --color-warning: #d4a85c;
+        --color-danger: #b85c5c;
+        --r-sm: 8px;
+        --r-md: 12px;
+        --r-lg: 16px;
+        --r-pill: 9999px;
+        --space-xs: 8px;
+        --space-sm: 12px;
+        --space-md: 16px;
+        --space-lg: 24px;
+        --touch: 56px; /* DESIGN.md spacing.touch — primary hit target for bottom tabs */
+        --nav-h: 64px; /* DESIGN.md bottom-nav height; tab min-height uses --touch */
+        --header-safe: max(12px, env(safe-area-inset-top, 0px));
+        --font-ui: system-ui, "Segoe UI", "SF Pro Text", "Helvetica Neue", "Noto Sans Hebrew", sans-serif;
+        --shadow-soft: 0 8px 24px rgba(10, 8, 6, 0.35);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: var(--space-lg);
+        background: #0e0c0a;
+        color: var(--color-ink-muted);
+        font-family: var(--font-ui);
+        line-height: 1.5;
+      }
+
+      .doc-title {
+        max-width: 1200px;
+        margin: 0 auto var(--space-lg);
+        padding-inline: var(--space-sm);
+      }
+
+      .doc-title h1 {
+        color: var(--color-ink);
+        font-size: 1.25rem;
+        font-weight: 600;
+        margin: 0 0 0.5rem;
+        letter-spacing: -0.01em;
+      }
+
+      .doc-title p {
+        margin: 0;
+        font-size: 0.875rem;
+        color: var(--color-ink-subtle);
+      }
+
+      .frames {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-lg);
+        justify-content: center;
+        align-items: flex-start;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+
+      .frame-block {
+        flex: 1 1 320px;
+        max-width: 380px;
+      }
+
+      .frame-label {
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--color-ink-subtle);
+        margin: 0 0 var(--space-sm);
+        padding-inline: 4px;
+      }
+
+      /* Phone shell */
+      .phone {
+        width: 100%;
+        max-width: 360px;
+        margin: 0 auto;
+        border-radius: 28px;
+        padding: 10px;
+        background: linear-gradient(145deg, #2a2622, #1a1816);
+        box-shadow: var(--shadow-soft);
+      }
+
+      .phone-notch {
+        height: 24px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 4px;
+      }
+
+      .phone-notch::before {
+        content: "";
+        width: 96px;
+        height: 22px;
+        background: #0a0908;
+        border-radius: 12px;
+      }
+
+      .screen {
+        border-radius: 20px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        min-height: 640px;
+        max-height: 720px;
+        background: var(--color-canvas);
+        border: 1px solid var(--color-border);
+      }
+
+      .layers-pair .screen {
+        min-height: 620px;
+        max-height: 720px;
+      }
+
+      .screen[dir="rtl"] {
+        direction: rtl;
+      }
+
+      /* Header (shared) */
+      .app-header {
+        background: var(--color-surface);
+        padding: calc(10px + var(--header-safe)) var(--space-md) var(--space-sm);
+        border-bottom: 1px solid var(--color-border);
+        flex-shrink: 0;
+      }
+
+      .app-header-top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-sm);
+        margin-bottom: 0;
+      }
+
+      .header-end {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex-shrink: 0;
+      }
+
+      .app-title {
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: var(--color-ink);
+        margin: 0;
+        line-height: 1.3;
+        letter-spacing: -0.01em;
+      }
+
+      .locale-toggle {
+        display: inline-flex;
+        border: 1px solid var(--color-border);
+        border-radius: var(--r-md);
+        overflow: hidden;
+        font-size: 0.75rem;
+        font-weight: 500;
+      }
+
+      .locale-toggle button {
+        border: none;
+        padding: 8px 10px;
+        min-height: 44px;
+        min-width: 44px;
+        background: var(--color-surface-raised);
+        color: var(--color-ink-muted);
+        cursor: default;
+        font: inherit;
+      }
+
+      .locale-toggle button.active {
+        background: var(--color-primary);
+        color: var(--color-on-primary);
+      }
+
+      /* Compact connection: lamp only (green = live; red = offline — see README) */
+      .status-pip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+      }
+
+      .status-pip .connection-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--color-success);
+        box-shadow: 0 0 0 2px rgba(122, 155, 122, 0.35);
+      }
+
+      .status-pip.is-off .connection-dot {
+        background: var(--color-danger);
+        box-shadow: 0 0 0 2px rgba(184, 92, 92, 0.35);
+      }
+
+      .connection-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--color-success);
+        box-shadow: 0 0 0 2px rgba(122, 155, 122, 0.35);
+      }
+
+      /* Main scroll region */
+      .app-main {
+        flex: 1;
+        min-height: 0;
+        overflow: auto;
+        padding: var(--space-md);
+        -webkit-overflow-scrolling: touch;
+      }
+
+      .panel-title-row {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: var(--space-sm);
+        margin-bottom: var(--space-sm);
+        flex-wrap: wrap;
+      }
+
+      .panel-title {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 600;
+        color: var(--color-ink);
+      }
+
+      .active-count {
+        font-size: 0.8125rem;
+        font-weight: 500;
+        color: var(--color-primary);
+        background: var(--color-surface-raised);
+        padding: 6px 12px;
+        border-radius: var(--r-pill);
+        border: 1px solid var(--color-border-strong);
+        white-space: nowrap;
+      }
+
+      .en-hint {
+        font-size: 0.65rem;
+        color: var(--color-ink-subtle);
+        font-weight: 500;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      /* Layers: dual-phone artifact — overview (all packs) + focused pack */
+      .frame-block--layers-dual {
+        flex: 1 1 680px;
+        max-width: 820px;
+      }
+
+      .layers-pair {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-lg);
+        justify-content: center;
+        align-items: stretch;
+        width: 100%;
+      }
+
+      .layers-pair .phone {
+        flex: 1 1 312px;
+        max-width: 360px;
+        margin: 0;
+      }
+
+      .app-main--layers-tight {
+        padding: 10px var(--space-sm) var(--space-sm);
+      }
+
+      .pack-grid-overview {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        padding-bottom: 6px;
+      }
+
+      .pack-tile {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        padding: 12px 12px;
+        border-radius: var(--r-md);
+        background: linear-gradient(
+          145deg,
+          rgba(38, 35, 32, 0.94),
+          rgba(22, 20, 18, 0.98)
+        );
+        border: 1px solid var(--color-border);
+        box-shadow:
+          0 4px 18px rgba(0, 0, 0, 0.28),
+          inset 0 1px 0 rgba(255, 255, 255, 0.04);
+      }
+
+      .pack-tile--dim {
+        opacity: 0.76;
+      }
+
+      .pack-tile--peek {
+        border-color: rgba(193, 127, 74, 0.5);
+        box-shadow:
+          0 0 0 1px rgba(193, 127, 74, 0.12),
+          0 6px 22px rgba(10, 8, 6, 0.38);
+      }
+
+      .pack-tile__main {
+        min-width: 0;
+        flex: 1;
+      }
+
+      .pack-tile__actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-shrink: 0;
+      }
+
+      .pack-tile__drill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 44px;
+        height: 44px;
+        border-radius: var(--r-sm);
+        border: 1px solid var(--color-border-strong);
+        background: var(--color-surface-raised);
+        color: var(--color-primary);
+        font-size: 1.1rem;
+        font-weight: 700;
+        line-height: 1;
+        letter-spacing: -0.06em;
+        cursor: default;
+        font-family: inherit;
+      }
+
+      .pack-tile .pack-master {
+        flex-direction: column;
+        align-items: center;
+        gap: 3px;
+      }
+
+      .pack-tile .pack-master-label {
+        font-size: 0.55rem;
+      }
+
+      .focus-strip {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 2px 2px 12px;
+        margin-bottom: 6px;
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      .fake-back {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 12px;
+        border-radius: var(--r-sm);
+        border: 1px solid var(--color-border);
+        background: var(--color-surface-raised);
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: var(--color-primary);
+        cursor: default;
+        font-family: inherit;
+      }
+
+      .focus-pack-title {
+        margin: 0;
+        flex: 1;
+        min-width: 0;
+        font-size: 0.95rem;
+        font-weight: 700;
+        color: var(--color-ink);
+        text-align: center;
+      }
+
+      .pack-box--focused {
+        margin-bottom: 0;
+      }
+
+      .pack-box--focused .pack-box__head-main {
+        flex: 1;
+        min-width: 0;
+      }
+
+      /* Pack box (Layers tab): one card per pack — master toggle + expand are separate */
+      .pack-box {
+        margin-bottom: var(--space-md);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--r-md);
+        overflow: hidden;
+      }
+
+      .pack-box__head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--space-sm);
+        padding: var(--space-sm) var(--space-md);
+        background: var(--color-surface-raised);
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      .pack-box__head-main {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--space-sm);
+        min-width: 0;
+        flex: 1;
+      }
+
+      .pack-name-block {
+        min-width: 0;
+        flex: 1;
+      }
+
+      .pack-title {
+        margin: 0;
+        font-size: 0.95rem;
+        font-weight: 700;
+        color: var(--color-ink);
+        line-height: 1.3;
+      }
+
+      .pack-stat {
+        display: block;
+        margin-top: 4px;
+        font-size: 0.7rem;
+        color: var(--color-ink-subtle);
+        font-weight: 500;
+      }
+
+      .pack-head-trailing {
+        display: flex;
+        align-items: flex-start;
+        gap: var(--space-sm);
+        flex-shrink: 0;
+      }
+
+      .pack-flow-pack {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        flex-shrink: 0;
+      }
+
+      .pack-flow-pack button.chip {
+        cursor: default;
+        font: inherit;
+      }
+
+      .pack-master {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        flex-shrink: 0;
+      }
+
+      .pack-master-label {
+        font-size: 0.6rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: var(--color-ink-subtle);
+        font-weight: 600;
+        white-space: nowrap;
+      }
+
+      .pack-box__rows {
+        padding: var(--space-sm) var(--space-sm) var(--space-md);
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .pack-box__rows[hidden] {
+        display: none;
+      }
+
+      .row-annot {
+        display: block;
+        font-size: 0.62rem;
+        color: var(--color-ink-subtle);
+        margin-top: 2px;
+        line-height: 1.35;
+      }
+
+      .row-grid {
+        display: grid;
+        grid-template-columns: 1fr auto auto;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .row-grid.no-anim {
+        grid-template-columns: 1fr auto;
+      }
+
+      .anim-col {
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 4px;
+      }
+
+      .anim-col.muted {
+        opacity: 0.45;
+        pointer-events: none;
+      }
+
+      .anim-skip {
+        font-size: 0.6rem;
+        color: var(--color-ink-subtle);
+        text-align: end;
+        max-width: 6.5rem;
+        line-height: 1.25;
+      }
+
+      .row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--space-sm);
+        padding: var(--space-sm);
+        margin-bottom: 6px;
+        background: var(--color-surface-raised);
+        border-radius: var(--r-sm);
+        border: 1px solid var(--color-border);
+        min-height: 52px;
+      }
+
+      .row.row-grid {
+        display: grid;
+        align-items: center;
+      }
+
+      .row-meta {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        min-width: 0;
+        flex: 1;
+      }
+
+      .row-title {
+        font-size: 0.875rem;
+        color: var(--color-ink);
+        font-weight: 500;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .row-badges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        align-items: center;
+      }
+
+      .badge {
+        font-size: 0.65rem;
+        font-weight: 600;
+        padding: 2px 8px;
+        border-radius: var(--r-pill);
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+      }
+
+      .badge-flow {
+        background: rgba(193, 127, 74, 0.15);
+        color: var(--color-primary);
+        border: 1px solid var(--color-border-strong);
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 6px 10px;
+        border-radius: var(--r-pill);
+        background: var(--color-surface);
+        color: var(--color-primary);
+        border: 1px solid var(--color-border-strong);
+        font-size: 0.75rem;
+        font-weight: 500;
+        white-space: nowrap;
+      }
+
+      .chip.muted {
+        color: var(--color-ink-muted);
+        border-color: var(--color-border);
+      }
+
+      .toggle {
+        width: 48px;
+        height: 28px;
+        border-radius: 14px;
+        background: var(--color-border-strong);
+        position: relative;
+        flex-shrink: 0;
+      }
+
+      .toggle::after {
+        content: "";
+        position: absolute;
+        width: 24px;
+        height: 24px;
+        top: 2px;
+        background: var(--color-ink);
+        border-radius: 50%;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+      }
+
+      .screen[dir="rtl"] .toggle::after {
+        right: 2px;
+      }
+
+      .screen[dir="ltr"] .toggle::after,
+      :not([dir="rtl"]) .toggle.on::after {
+        right: 2px;
+        left: auto;
+      }
+
+      .toggle.on {
+        background: var(--color-primary);
+      }
+
+      .screen[dir="rtl"] .toggle.on::after {
+        right: 2px;
+      }
+
+      /* Navigation tab: same affordances as current main controller — controls are primary */
+      .map-sliver {
+        background: linear-gradient(180deg, #1a1816, var(--color-surface));
+        border: 1px solid var(--color-border);
+        border-radius: var(--r-md);
+        padding: var(--space-sm) var(--space-md);
+        min-height: 52px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--color-ink-subtle);
+        font-size: 0.75rem;
+        text-align: center;
+        line-height: 1.35;
+        flex-shrink: 0;
+      }
+
+      .controls-hero {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        gap: var(--space-md);
+        margin-top: var(--space-sm);
+      }
+
+      .nav-main {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
+        padding: var(--space-md);
+        -webkit-overflow-scrolling: touch;
+        overflow: auto;
+      }
+
+      .controls-row {
+        display: grid;
+        grid-template-columns: 1fr 1.45fr 1fr;
+        gap: var(--space-md);
+        align-items: stretch;
+        min-height: 168px;
+      }
+
+      .dpad {
+        background: var(--color-surface-raised);
+        border-radius: var(--r-md);
+        border: 1px solid var(--color-border);
+        aspect-ratio: 1;
+        min-height: 120px;
+        max-height: 160px;
+        display: grid;
+        place-items: center;
+        place-self: center;
+        width: 100%;
+        color: var(--color-ink-muted);
+        font-size: 1.75rem;
+        font-weight: 300;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+      }
+
+      .joystick {
+        background: radial-gradient(
+            circle at 50% 45%,
+            #322e2a 0%,
+            var(--color-surface-raised) 55%
+          );
+        border-radius: 50%;
+        border: 1px solid var(--color-border-strong);
+        min-height: 120px;
+        min-width: 120px;
+        max-height: 150px;
+        max-width: 150px;
+        margin: 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--color-ink-muted);
+        font-size: 0.72rem;
+        text-align: center;
+        padding: 8px;
+        line-height: 1.3;
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+      }
+
+      .zoom-block {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .zoom-bar {
+        height: 8px;
+        background: var(--color-border);
+        border-radius: 4px;
+        position: relative;
+        overflow: hidden;
+      }
+
+      .zoom-bar::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        width: 60%;
+        background: var(--color-primary);
+        border-radius: 4px;
+      }
+
+      .zoom-btns {
+        display: flex;
+        justify-content: space-between;
+        gap: 6px;
+      }
+
+      .zoom-btns .icon-btn {
+        min-height: 48px;
+        font-size: 1.1rem;
+      }
+
+      .icon-btn {
+        flex: 1;
+        min-height: 44px;
+        border-radius: var(--r-sm);
+        border: 1px solid var(--color-border);
+        background: var(--color-surface);
+        color: var(--color-ink);
+        font-size: 0.75rem;
+        font-weight: 600;
+      }
+
+      /* Workshop (same curation embed contract as today; visual refresh only) */
+      .workshop-surface {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        padding: var(--space-sm) var(--space-md) 0;
+        gap: var(--space-sm);
+      }
+
+      .workshop-intro {
+        margin: 0;
+        font-size: 0.8rem;
+        color: var(--color-ink-subtle);
+        line-height: 1.45;
+      }
+
+      .workshop-badges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+
+      .wb {
+        font-size: 0.65rem;
+        font-weight: 600;
+        padding: 4px 10px;
+        border-radius: var(--r-pill);
+        border: 1px solid var(--color-border);
+        color: var(--color-ink-muted);
+        background: var(--color-surface-raised);
+        letter-spacing: 0.03em;
+      }
+
+      .wb-accent {
+        border-color: var(--color-primary);
+        color: var(--color-primary);
+        background: rgba(193, 127, 74, 0.1);
+      }
+
+      .iframe-placeholder {
+        flex: 1;
+        min-height: 200px;
+        margin: 0 0 var(--space-sm);
+        border: 1px solid var(--color-border-strong);
+        border-radius: var(--r-lg);
+        background: linear-gradient(165deg, #232019 0%, #181512 100%);
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: center;
+        padding: var(--space-md);
+        text-align: center;
+        color: var(--color-ink-muted);
+        font-size: 0.875rem;
+        gap: var(--space-sm);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+      }
+
+      .iframe-title {
+        color: var(--color-ink);
+        font-weight: 700;
+        font-size: 1rem;
+        letter-spacing: -0.01em;
+      }
+
+      .iframe-url {
+        font-family: ui-monospace, monospace;
+        font-size: 0.7rem;
+        color: var(--color-ink-subtle);
+        word-break: break-all;
+        max-width: 100%;
+      }
+
+      /* Bottom nav */
+      .bottom-nav {
+        flex-shrink: 0;
+        display: flex;
+        align-items: stretch;
+        background: var(--color-surface);
+        border-top: 1px solid var(--color-border);
+        padding: var(--space-sm) var(--space-sm)
+          max(8px, env(safe-area-inset-bottom, 0px));
+        min-height: var(--nav-h);
+        gap: 4px;
+      }
+
+      .nav-tab {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 2px;
+        border: none;
+        background: transparent;
+        color: var(--color-ink-muted);
+        font-family: inherit;
+        font-size: 0.75rem;
+        font-weight: 600;
+        line-height: 1.2;
+        letter-spacing: 0.04em;
+        min-height: var(--touch);
+        min-width: var(--touch);
+        border-radius: var(--r-md);
+        padding: 6px 4px;
+        cursor: default;
+      }
+
+      .nav-tab .nav-ico {
+        font-size: 1.1rem;
+        line-height: 1;
+        opacity: 0.9;
+      }
+
+      .nav-tab.is-active {
+        background: var(--color-surface-raised);
+        color: var(--color-primary);
+      }
+
+      .note-strip {
+        margin: var(--space-lg) auto 0;
+        max-width: 1200px;
+        padding: var(--space-md);
+        border-radius: var(--r-md);
+        border: 1px solid var(--color-border);
+        background: var(--color-surface);
+        font-size: 0.8rem;
+        color: var(--color-ink-muted);
+      }
+
+      .note-strip strong {
+        color: var(--color-ink);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="doc-title">
+      <h1>OTEF Remote — static mockups (Task 2 · iteration)</h1>
+      <p>
+        Negev/terracotta tokens from
+        <code>otef-interactive/frontend/DESIGN.md</code> · Hebrew-default RTL
+        · no JS — Navigation / Layers (dual-phone: overview → focused pack) /
+        Workshop.
+        <span lang="en"
+          ><strong>Task 6 parity:</strong> drill-in from overview to a focused pack
+          is the UX equivalent of the previous in-list group expand/collapse (same
+          model/actions; navigation pattern only changes).</span
+        >
+      </p>
+    </div>
+
+    <div class="frames">
+      <!-- Navigation: primary = D-pad, joystick, zoom (no layers UI; table switcher omitted in mockup) -->
+      <div class="frame-block">
+        <p class="frame-label">1 · Navigation</p>
+        <div class="phone" aria-label="Mockup: Navigation tab">
+          <div class="phone-notch" aria-hidden="true"></div>
+          <div class="screen" dir="rtl" lang="he">
+            <header class="app-header">
+              <div class="app-header-top">
+                <h1 class="app-title">OTEF מרחוק</h1>
+                <div class="header-end">
+                  <span
+                    class="status-pip"
+                    title="מחובר"
+                    aria-label="מצב חיבור: מחובר"
+                  >
+                    <span class="connection-dot" aria-hidden="true"></span>
+                  </span>
+                  <div
+                    class="locale-toggle"
+                    title="Bilingual: Hebrew | English (labels)"
+                    aria-label="החלפת שפה"
+                  >
+                    <button type="button" class="active" lang="he">עברית</button>
+                    <button type="button" lang="en">EN</button>
+                  </div>
+                </div>
+              </div>
+            </header>
+
+            <main class="nav-main" aria-label="ניווט — בקרים">
+              <div class="map-sliver" lang="he">תצוגת שולחן (רקע) — הדגשה בבקרים</div>
+              <div class="controls-hero">
+                <p class="en-hint" style="margin: 0" lang="en">
+                  D-pad · joystick · zoom (main controller)
+                </p>
+                <div class="controls-row" lang="he">
+                  <div class="dpad" aria-hidden="true">+</div>
+                  <div class="joystick">מוט<br />שליטה</div>
+                  <div class="zoom-block">
+                    <div class="zoom-bar" title="רמת זום"></div>
+                    <div class="zoom-btns">
+                      <button type="button" class="icon-btn">−</button>
+                      <button type="button" class="icon-btn">+</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </main>
+
+            <nav class="bottom-nav" role="tablist" aria-label="לשוניות ראשיות">
+              <button type="button" class="nav-tab is-active" aria-selected="true">
+                <span class="nav-ico" aria-hidden="true">◎</span>
+                <span lang="he">ניווט</span>
+              </button>
+              <button type="button" class="nav-tab" aria-selected="false">
+                <span class="nav-ico" aria-hidden="true">◫</span>
+                <span lang="he">שכבות</span>
+              </button>
+              <button type="button" class="nav-tab" aria-selected="false">
+                <span class="nav-ico" aria-hidden="true">✎</span>
+                <span lang="he">סדנה</span>
+              </button>
+            </nav>
+          </div>
+        </div>
+      </div>
+
+      <!-- Layers: overview + focused pack (no endless in-panel scroll in this comp; overflow → bounded scroll — see note-strip) -->
+      <div class="frame-block frame-block--layers-dual">
+        <p class="frame-label">
+          2 · Layers
+          <span class="en-hint" lang="en" style="font-weight: 500; margin-inline-start: 6px"
+            >overview · focused pack</span
+          >
+        </p>
+        <p
+          class="en-hint"
+          style="margin: -6px 0 12px; padding-inline: 4px; text-align: center; line-height: 1.45"
+          lang="he"
+        >
+          שני מצבי מסך סטטיים זה לצד זה — מבט־על על כל החבילות, ומבט מלא אחרי פתיחת חבילה
+          (כאן: <strong style="color: var(--color-ink)">זרימה</strong>).
+        </p>
+
+        <div class="layers-pair" aria-label="הדגמת שכבות: סקירה ומבט ממוקד">
+          <!-- A: pack overview — master toggle ≠ open/drill -->
+          <div class="phone" aria-label="Mockup: Layers — מבט על חבילות">
+            <div class="phone-notch" aria-hidden="true"></div>
+            <div class="screen" dir="rtl" lang="he">
+              <header class="app-header">
+                <div class="app-header-top">
+                  <h1 class="app-title" style="margin: 0">OTEF מרחוק</h1>
+                  <div class="header-end">
+                    <span
+                      class="status-pip"
+                      title="מחובר"
+                      aria-label="מצב חיבור: מחובר"
+                    >
+                      <span class="connection-dot" aria-hidden="true"></span>
+                    </span>
+                    <div class="locale-toggle">
+                      <button type="button" class="active" lang="he">עברית</button>
+                      <button type="button" lang="en">EN</button>
+                    </div>
+                  </div>
+                </div>
+              </header>
+
+              <main class="app-main app-main--layers-tight">
+                <div class="panel-title-row">
+                  <h2 class="panel-title" lang="he">שכבות</h2>
+                  <div
+                    class="active-count"
+                    title="סה״כ שכבות מופעלות (מצטבר לפי ids)"
+                  >
+                    <span lang="he">5 פעילות</span>
+                    <span class="en-hint" lang="en" style="margin-inline-start: 6px"
+                      >· 5 on</span
+                    >
+                  </div>
+                </div>
+
+                <p
+                  class="en-hint"
+                  style="margin: 0 0 10px; font-size: 0.62rem; line-height: 1.45"
+                  lang="en"
+                >
+                  All packs visible in this comp; if real data exceeds the
+                  viewport, use <strong>bounded scroll inside the Layers panel</strong>
+                  (not an endless single flat list). <strong>Open</strong> (drill ››)
+                  is separate from the <strong>pack</strong> master toggle.
+                </p>
+
+                <div class="pack-grid-overview">
+                  <div class="pack-tile" data-mock="pack tile">
+                    <div class="pack-tile__main">
+                      <h3 class="pack-title" style="margin: 0 0 2px" lang="he">יישובים</h3>
+                      <span class="pack-stat" lang="he">2 פעילים · 4 בשכבה</span>
+                    </div>
+                    <div class="pack-tile__actions">
+                      <button
+                        type="button"
+                        class="pack-tile__drill"
+                        title="פתח חבילה — מסך ממוקד (מופרד מהדלקת חבילה)"
+                        aria-label="פתח חבילה"
+                      >
+                        ››
+                      </button>
+                      <div class="pack-master">
+                        <span class="pack-master-label" lang="he">חבילה</span>
+                        <div class="toggle on" title="הפעל/כבה את כל החבילה"></div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="pack-tile pack-tile--peek" data-mock="pack matching focused demo">
+                    <div class="pack-tile__main">
+                      <h3 class="pack-title" style="margin: 0 0 2px" lang="he">זרימה</h3>
+                      <span class="pack-stat" lang="he"
+                        >1 פעיל · 2 בשכבה · אנימציה בחבילה</span
+                      >
+                      <span class="row-annot" lang="he" style="margin-top: 4px; display: block"
+                        >מסומן — אותה חבילה במבט הממוקד לצד</span
+                      >
+                    </div>
+                    <div class="pack-tile__actions">
+                      <button
+                        type="button"
+                        class="pack-tile__drill"
+                        title="פתוח בהדגמה במסך הממוקד"
+                        aria-label="פתח חבילה"
+                      >
+                        ››
+                      </button>
+                      <div class="pack-master">
+                        <span class="pack-master-label" lang="he">חבילה</span>
+                        <div class="toggle on" title="כל החבילה"></div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="pack-tile pack-tile--dim">
+                    <div class="pack-tile__main">
+                      <h3 class="pack-title" style="margin: 0 0 2px" lang="he">תשתית</h3>
+                      <span class="pack-stat" lang="he">0 פעילים · 6 בשכבה</span>
+                    </div>
+                    <div class="pack-tile__actions">
+                      <button
+                        type="button"
+                        class="pack-tile__drill"
+                        title="פתח חבילה (גם כשהחבילה כבויה — ניווט בלבד)"
+                        aria-label="פתח חבילה"
+                      >
+                        ››
+                      </button>
+                      <div class="pack-master">
+                        <span class="pack-master-label" lang="he">חבילה</span>
+                        <div class="toggle" title="חבילה כבויה"></div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="pack-tile">
+                    <div class="pack-tile__main">
+                      <h3 class="pack-title" style="margin: 0 0 2px" lang="he">מגזרים</h3>
+                      <span class="pack-stat" lang="he">2 פעילים · 5 בשכבה</span>
+                    </div>
+                    <div class="pack-tile__actions">
+                      <button
+                        type="button"
+                        class="pack-tile__drill"
+                        title="פתח חבילה"
+                        aria-label="פתח חבילה"
+                      >
+                        ››
+                      </button>
+                      <div class="pack-master">
+                        <span class="pack-master-label" lang="he">חבילה</span>
+                        <div class="toggle on" title="חבילה פעילה"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </main>
+
+              <nav class="bottom-nav" role="tablist" aria-label="לשוניות">
+                <button type="button" class="nav-tab" aria-selected="false">
+                  <span class="nav-ico" aria-hidden="true">◎</span>
+                  <span lang="he">ניווט</span>
+                </button>
+                <button type="button" class="nav-tab is-active" aria-selected="true">
+                  <span class="nav-ico" aria-hidden="true">◫</span>
+                  <span lang="he">שכבות</span>
+                </button>
+                <button type="button" class="nav-tab" aria-selected="false">
+                  <span class="nav-ico" aria-hidden="true">✎</span>
+                  <span lang="he">סדנה</span>
+                </button>
+              </nav>
+            </div>
+          </div>
+
+          <!-- B: focused pack — rows, visibility ≠ animation, mixed anim example -->
+          <div class="phone" aria-label="Mockup: Layers — חבילת זרימה (ממוקד)">
+            <div class="phone-notch" aria-hidden="true"></div>
+            <div class="screen" dir="rtl" lang="he">
+              <header class="app-header">
+                <div class="app-header-top">
+                  <h1 class="app-title" style="margin: 0">OTEF מרחוק</h1>
+                  <div class="header-end">
+                    <span
+                      class="status-pip"
+                      title="מחובר"
+                      aria-label="מצב חיבור: מחובר"
+                    >
+                      <span class="connection-dot" aria-hidden="true"></span>
+                    </span>
+                    <div class="locale-toggle">
+                      <button type="button" class="active" lang="he">עברית</button>
+                      <button type="button" lang="en">EN</button>
+                    </div>
+                  </div>
+                </div>
+              </header>
+
+              <main class="app-main app-main--layers-tight">
+                <div class="focus-strip">
+                  <button type="button" class="fake-back" lang="he">‹ כל החבילות</button>
+                  <h2 class="focus-pack-title" lang="he">זרימה</h2>
+                </div>
+
+                <p
+                  class="en-hint"
+                  style="margin: 0 0 10px; font-size: 0.62rem; line-height: 1.45"
+                  lang="en"
+                >
+                  Focused view: per-row visibility + animation where applicable.
+                  Pack-level Flow stays in the header; rows can show mixed animation.
+                  <strong>Non-flow pack:</strong> omit Flow header + animation column;
+                  visibility-only rows (flow-category chip still OK when relevant).
+                </p>
+
+                <article class="pack-box pack-box--focused" data-mock="focused pack">
+                  <div class="pack-box__head">
+                    <div class="pack-box__head-main">
+                      <div class="pack-name-block">
+                        <span class="pack-stat" lang="he"
+                          >1 פעיל · 2 שכבות · שליטת זרם ברמת חבילה</span
+                        >
+                      </div>
+                    </div>
+                    <div class="pack-head-trailing">
+                      <div
+                        class="pack-flow-pack"
+                        title="שליטת זרם ברמת חבילה — נפרדת משורות"
+                      >
+                        <span class="pack-master-label" lang="he">זרם · חבילה</span>
+                        <button type="button" class="chip" lang="he">זרם · פעיל</button>
+                      </div>
+                      <div class="pack-master">
+                        <span class="pack-master-label" lang="he">חבילה</span>
+                        <div class="toggle on" title="כל החבילה"></div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="pack-box__rows">
+                    <div class="row row-grid" style="margin: 0">
+                      <div class="row-meta">
+                        <div class="row-title" lang="he">החלקה שנתית</div>
+                        <div class="row-badges">
+                          <span class="badge badge-flow" lang="he">זרם</span>
+                        </div>
+                        <span class="row-annot" lang="he"
+                          >שורה אחת יכולה לייצג מספר מזהי שכבה — בלי תגיות טכניות
+                          רועשות</span
+                        >
+                      </div>
+                      <div class="toggle on" title="מוצג"></div>
+                      <div class="anim-col">
+                        <span class="chip" lang="he">אנימציה · פעיל</span>
+                        <span class="row-annot" lang="he">נפרד מנראות</span>
+                      </div>
+                    </div>
+                    <div class="row row-grid" style="margin: 0">
+                      <div class="row-meta">
+                        <div class="row-title" lang="he">רשת דקה</div>
+                        <div class="row-badges">
+                          <span class="badge badge-flow" lang="he">זרם</span>
+                        </div>
+                      </div>
+                      <div class="toggle" title="מוסתר"></div>
+                      <div class="anim-col">
+                        <span class="chip muted" lang="he">אנימציה · כבוי</span>
+                        <span class="row-annot" lang="he" style="font-size: 0.6rem"
+                          >מצב מעורב באותה חבילה</span
+                        >
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              </main>
+
+              <nav class="bottom-nav" role="tablist" aria-label="לשוניות">
+                <button type="button" class="nav-tab" aria-selected="false">
+                  <span class="nav-ico" aria-hidden="true">◎</span>
+                  <span lang="he">ניווט</span>
+                </button>
+                <button type="button" class="nav-tab is-active" aria-selected="true">
+                  <span class="nav-ico" aria-hidden="true">◫</span>
+                  <span lang="he">שכבות</span>
+                </button>
+                <button type="button" class="nav-tab" aria-selected="false">
+                  <span class="nav-ico" aria-hidden="true">✎</span>
+                  <span lang="he">סדנה</span>
+                </button>
+              </nav>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Workshop: same curation surface as today (iframe embed, parent heartbeat) — visual refresh only -->
+      <div class="frame-block">
+        <p class="frame-label">3 · Workshop (סדנה) <span class="en-hint" lang="en">EN: workshop</span></p>
+        <div class="phone" aria-label="Mockup: Workshop tab">
+          <div class="phone-notch" aria-hidden="true"></div>
+          <div
+            class="screen"
+            dir="rtl"
+            lang="he"
+            style="min-height: 640px; display: flex; flex-direction: column"
+          >
+            <header class="app-header">
+              <div class="app-header-top">
+                <h1 class="app-title" style="margin: 0">OTEF מרחוק</h1>
+                <div class="header-end">
+                  <span
+                    class="status-pip"
+                    title="מחובר"
+                    aria-label="מצב חיבור: מחובר"
+                  >
+                    <span class="connection-dot" aria-hidden="true"></span>
+                  </span>
+                  <div class="locale-toggle">
+                    <button type="button" class="active" lang="he">עברית</button>
+                    <button type="button" lang="en">EN</button>
+                  </div>
+                </div>
+              </div>
+            </header>
+
+            <div
+              class="workshop-surface"
+              data-mock="curation.html embed (unchanged contract)"
+            >
+              <p class="workshop-intro" lang="he">
+                <strong style="color: var(--color-ink)">סדנה</strong>
+                — אותו זרימת אוצרות כמו היום: מסמך מוטמע, ללא לוגיקה נוספת בטאב.
+              </p>
+              <p class="workshop-intro" lang="en" style="font-size: 0.72rem">
+                Same curation experience as the current app; English label
+                for the tab: <strong>workshop</strong>.
+              </p>
+              <div class="workshop-badges" aria-hidden="true">
+                <span class="wb wb-accent" lang="he">הטמעה (iframe)</span>
+                <span class="wb" lang="he">Supabase · parent heartbeat</span>
+                <span class="wb" lang="en">?embed=1</span>
+              </div>
+              <div class="iframe-placeholder" data-mock="curation.html?embed=1">
+                <div class="iframe-title" lang="he">אזור עבודת אוצרות</div>
+                <p lang="he" style="margin: 0; font-size: 0.82rem; line-height: 1.5">
+                  כאן יוצג ה־iframe הקיים. Supabase/heartbeat — רק ביישום המארח, לא
+                  בתוכן הiframe.
+                </p>
+                <code class="iframe-url" dir="ltr" lang="en"
+                  >curation.html?embed=1</code
+                >
+                <p class="en-hint" style="margin: 0" lang="en">
+                  Layout / safe area only — no new capabilities
+                </p>
+              </div>
+            </div>
+
+            <nav
+              class="bottom-nav"
+              role="tablist"
+              style="margin-top: auto"
+              aria-label="לשוניות"
+            >
+              <button type="button" class="nav-tab" aria-selected="false">
+                <span class="nav-ico" aria-hidden="true">◎</span>
+                <span lang="he">ניווט</span>
+              </button>
+              <button type="button" class="nav-tab" aria-selected="false">
+                <span class="nav-ico" aria-hidden="true">◫</span>
+                <span lang="he">שכבות</span>
+              </button>
+              <button type="button" class="nav-tab is-active" aria-selected="true">
+                <span class="nav-ico" aria-hidden="true">✎</span>
+                <span lang="he">סדנה</span>
+              </button>
+            </nav>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="note-strip" lang="en">
+      <p style="margin: 0 0 10px">
+        <strong>Layers model (OTEF behavior — annotations for implementers):</strong>
+        Packs in the app come from the <em>effective layer groups at runtime</em>
+        and may include <em>curated</em> special handling (e.g. merge). Some list
+        rows can represent <em>several</em> full layer ids — without noisy
+        processed/curated/raw-id badges in the UI; a compact
+        <strong>flow-category</strong> indicator (e.g. זרם) is allowed when it
+        clarifies semantics. A row’s
+        <strong>visibility</strong> toggle and its <strong>animation</strong>
+        control are <em>independent</em> where the layer supports animation.
+        <strong>Flow packs</strong> retain <em>pack-level</em> Flow control in the
+        focused pack header (current-behavior parity); <em>row-level</em> animation
+        chips are separate. The mockup shows <em>mixed</em> per-row animation in
+        the adjacent <strong>זרימה</strong> focused phone. Overview uses a
+        <strong>pack master</strong> toggle separate from the <strong>open/drill</strong>
+        control. Overflow: if pack tiles or focused rows exceed the visible area,
+        scroll inside the tab/panel container — the mockup avoids implying a
+        single endless scroll of all layers at once.
+        Table switcher and full connection copy are
+        <strong>omitted from these mockup frames</strong> on purpose; only a
+        green/red <strong>lamp</strong> is shown (offline =
+        <code>status-pip is-off</code> in a future comp).
+      </p>
+      <p style="margin: 0; font-size: 0.75rem; color: #8c847a">
+        Static HTML only. Open this file in a browser for review. See
+        <code>README.md</code> in this folder.
+      </p>
+    </div>
+  </body>
+</html>

--- a/otef-interactive/frontend/DESIGN.md
+++ b/otef-interactive/frontend/DESIGN.md
@@ -1,0 +1,196 @@
+---
+version: alpha
+name: OTEF Remote Controller — Negev Urban Research Lab
+description: >
+  Mobile-first remote for OTEF wall sessions: warm Negev dark (stone + charcoal),
+  single terracotta accent, Hebrew-default chrome with English toggle. Tokens map
+  to CSS variables in css/remote-styles.css; behavior stays on OTEFDataContext,
+  existing WebSocket/API, and layer-sheet logic (full-height panel, not drawer).
+colors:
+  primary: "#c17f4a"
+  canvas: "#12100e"
+  surface: "#1c1917"
+  surface-raised: "#262320"
+  ink: "#f5f0ea"
+  ink-muted: "#bfb6ab"
+  ink-subtle: "#8c847a"
+  primary-hover: "#d4925e"
+  on-primary: "#141210"
+  border: "#3d3834"
+  border-strong: "#4a4540"
+  success: "#7a9b7a"
+  warning: "#d4a85c"
+  danger: "#b85c5c"
+  overlay-scrim: "#0a0908"
+typography:
+  title-sm:
+    fontFamily: system-ui, "Segoe UI", "SF Pro Text", "Helvetica Neue", sans-serif
+    fontSize: 1.125rem
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: "-0.01em"
+  body-md:
+    fontFamily: system-ui, "Segoe UI", "SF Pro Text", "Helvetica Neue", "Noto Sans Hebrew", sans-serif
+    fontSize: 1rem
+    fontWeight: 400
+    lineHeight: 1.5
+  label-sm:
+    fontFamily: system-ui, "Segoe UI", "SF Pro Text", "Helvetica Neue", "Noto Sans Hebrew", sans-serif
+    fontSize: 0.8125rem
+    fontWeight: 500
+    lineHeight: 1.4
+    letterSpacing: "0.02em"
+  tab-label:
+    fontFamily: system-ui, "Segoe UI", "SF Pro Text", "Helvetica Neue", "Noto Sans Hebrew", sans-serif
+    fontSize: 0.75rem
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "0.04em"
+rounded:
+  sm: 8px
+  md: 12px
+  lg: 16px
+  pill: 9999px
+spacing:
+  xs: 8px
+  sm: 12px
+  md: 16px
+  lg: 24px
+  touch: 56px
+components:
+  app-background:
+    backgroundColor: "{colors.canvas}"
+  hairline-divider:
+    backgroundColor: "{colors.border}"
+    height: 1px
+  hairline-divider-strong:
+    backgroundColor: "{colors.border-strong}"
+    height: 1px
+  modal-scrim:
+    backgroundColor: "{colors.overlay-scrim}"
+  supporting-text:
+    textColor: "{colors.ink-subtle}"
+    typography: "{typography.label-sm}"
+  header:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    typography: "{typography.title-sm}"
+    padding: "{spacing.md}"
+  bottom-nav:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink-muted}"
+    padding: "{spacing.sm}"
+    height: 64px
+  nav-tab-active:
+    backgroundColor: "{colors.surface-raised}"
+    textColor: "{colors.primary}"
+    typography: "{typography.tab-label}"
+    rounded: "{rounded.md}"
+  nav-tab-inactive:
+    backgroundColor: transparent
+    textColor: "{colors.ink-muted}"
+    typography: "{typography.tab-label}"
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.label-sm}"
+    rounded: "{rounded.md}"
+    padding: 12px
+  button-primary-hover:
+    backgroundColor: "{colors.primary-hover}"
+    textColor: "{colors.on-primary}"
+  layer-row:
+    backgroundColor: "{colors.surface-raised}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.sm}"
+    padding: "{spacing.sm}"
+  animation-chip:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.primary}"
+    typography: "{typography.label-sm}"
+    rounded: "{rounded.pill}"
+    padding: 6px
+  connection-status-connected:
+    textColor: "{colors.success}"
+  connection-status-connecting:
+    textColor: "{colors.warning}"
+  connection-status-disconnected:
+    textColor: "{colors.danger}"
+---
+
+## Overview
+
+The OTEF Remote Controller is a **mobile-first** phone/tablet UI for the Negev Urban Research Lab wall: pan/zoom, GIS table context, layer visibility and time animation, plus curation. Visual tone is **quiet desert instrumentation**—warm charcoal and stone, **one terracotta** primary (`colors.primary`), matte surfaces, no cyan-on-black or neon glow. **Hebrew is default** (`lang="he"`, `dir="rtl"`); a compact **Hebrew | English** toggle in the header switches locale and mirrored layout (logical CSS). **Three bottom tabs**—Navigation, Layers, Curation—replace scattered entry points; Layers is a **full-height scrollable panel** (not a draggable bottom sheet) with **no loss** of grouping, toggles, animation chips, pack/processed behaviors, or OTEFDataContext wiring. **Curation** embeds same-origin `curation.html` in an iframe; parent owns the **single Supabase heartbeat**; embedded app skips duplicate init when an **embed flag** (e.g. `?embed=1`) is present—see implementation plan Task 7. **Layer row labels** use `formatLayerLabelForDisplay` in **`src/shared/layer-name-utils.js`** (underscores/hyphen noise → spaces for display only; canonical ids and `fullLayerIds` unchanged). **Switching away from the Layers tab** does not clear drill-down: reopening **Layers** shows the same focused pack; the in-panel **Back** control returns to the pack overview.
+
+## Colors
+
+- **Primary (`#c17f4a`)** — Terracotta for primary actions, active tab label, focus emphasis, animation chip text. Hover **`primary-hover` (`#d4925e`)**. **`on-primary` (`#141210`)** on filled buttons.
+- **Canvas (`#12100e`)** — App root / main backdrop; deepest warm charcoal (basalt), not blue-black. See `app-background`.
+- **Surface (`#1c1917`)** — Header, bottom nav, dense panels.
+- **Surface raised (`#262320`)** — Layer rows, active tab well, overlay cards.
+- **Ink (`#f5f0ea`) / Ink muted (`#bfb6ab`) / Ink subtle (`#8c847a`)** — Body, secondary, tertiary; `supporting-text` binds subtle ink for captions.
+- **Border (`#3d3834`) / Border strong (`#4a4540`)** — 1px dividers and chip outlines. Token use: `hairline-divider` / `hairline-divider-strong` (1px hairline swatches for lintable refs); in CSS prefer `border-color: var(--color-border)`.
+- **Success / Warning / Danger (`#7a9b7a` / `#d4a85c` / `#b85c5c`)** — Connection dot + status copy only; do not replace terracotta for generic highlights.
+- **Overlay scrim (`#0a0908`)** — Base for connection / warning overlays; use ~70–85% alpha in CSS. See `modal-scrim`.
+
+**Contrast:** **Ink on surface** and **on-primary on primary** target **WCAG AA** (≥4.5:1) for normal text.
+
+## Typography
+
+- **Stack:** `system-ui`, `Segoe UI`, `SF Pro Text`, `Helvetica Neue`, **`Noto Sans Hebrew`**, sans-serif.
+- **title-sm** — App bar / section titles (~18px semibold).
+- **body-md** — Descriptions, status, body UI (16px regular, RTL-friendly line height).
+- **label-sm** — Buttons, chips, counts (~13px medium).
+- **tab-label** — Bottom nav (12px semibold; keep Hebrew strings short).
+
+Implementation: **logical properties** (`padding-inline`, `margin-inline`, `inset-inline-*`) so English (`dir="ltr"`) mirrors without one-off overrides.
+
+## Layout
+
+- **Viewport:** `100dvh`, column flex: **fixed header** → **scrollable `main`** (active tab body) → **fixed bottom nav**; `env(safe-area-inset-*)` on header and nav.
+- **Header:** Title/branding, **locale toggle**, **connection** cluster; **below**, full-width **`#table-switcher`** (existing mount contract unchanged).
+- **Tab panels:** Three regions, each with **`data-remote-tab`** set to **`navigation`**, **`layers`**, or **`curation`** (exact attribute/value names are CI contracts—keep in sync with `html-entrypoint-contract`). Only one panel visible at a time; **Layers** hosts list + **panel header** (title + **active layer count**). **Curation** panel holds **iframe** (`title` localized); **do not** tear down iframe on tab switches unless memory forces it.
+- **Navigation tab:** D-pad, nipplejs joystick, zoom slider + step controls (existing behavior/throttle preserved).
+- **Layers tab:** Full-page list; same actions as current sheet (groups, chevrons, row toggles, pack/processed rows, animation chips).
+- **Touch:** Prefer **`spacing.touch` (56px)** on pad, zoom, and nav targets; 8–16px gaps between hit areas.
+
+## Elevation & Depth
+
+- Default **no glow**. Shadows: subtle warm black `rgba(10, 8, 6, 0.35)`, small blur; pressed controls optional inner highlight `rgba(245, 240, 234, 0.06)`.
+- **Bottom nav:** Prefer **1px top border** using **`border`** token; keep shadow minimal.
+- **Connection overlay:** Full-screen scrim (`modal-scrim` + alpha) + centered **`surface-raised`** card, **`rounded.lg`**, focus trap, one clear primary action. **`#warningOverlay`** (or current id) stays **global** across tabs.
+
+## Shapes
+
+- **rounded.sm / md / lg / pill** — 8 / 12 / 16px; pill for chips.
+- **Joystick / D-pad:** Geometry unchanged; icons **ink-muted**, **primary** on active press.
+
+## Components
+
+- **app-background** — Root fill: **`{colors.canvas}`**.
+- **header** — **`{colors.surface}`**, title **`title-sm`** / **ink**; table switcher row full-bleed under chrome.
+- **bottom-nav** — **`{colors.surface}`**, inactive labels **ink-muted**; **three** items only (Navigation / Layers / Curation). **Active:** `nav-tab-active` (raised + terracotta label); **inactive:** `nav-tab-inactive`.
+- **button-primary** / **button-primary-hover** — Filled CTA; focus ring ~2px **primary** at ~35% opacity outside control.
+- **layer-row** — Raised row, **ink** title; **1px `border`** token in CSS between rows or on card edge as today’s density requires.
+- **animation-chip** — Pill, **primary** text on **surface**; outline via CSS **`border-strong`**.
+- **connection-status-*** — Dot + label: connected **success**, connecting **warning** (subtle pulse), disconnected **danger**; motion under ~2s period.
+- **modal-scrim** — **`{colors.overlay-scrim}`** as solid base before alpha.
+- **supporting-text** — Tertiary copy: **`ink-subtle`** + **`label-sm`**.
+
+Map tokens to CSS custom properties (e.g. `--color-canvas`, `--color-primary`, `--nav-height`) in **`css/remote-styles.css`**; markup lives in **`remote-controller.html`** per Tasks 3–4.
+
+## Do's and Don'ts
+
+**Do**
+
+- Keep **warm neutrals** + **one terracotta**; reserve green/amber/red for **connection semantics** only.
+- Default **Hebrew** and **RTL**; toggle updates `lang`, `dir`, and mirrored spacing.
+- Preserve **OTEFDataContext**, **WebSocket/API**, **layer sheet** behaviors when moving to the Layers tab; preserve **nipplejs**, **`#table-switcher`**, **global overlay**, and **single parent heartbeat** for curation embed.
+- Localize visible strings per locale module; format row labels with **`formatLayerLabelForDisplay`** (`layer-name-utils.js`) only—never rewrite canonical ids.
+
+**Don't**
+
+- Don’t use **cyan/teal** as primary accent or **matrix** glow aesthetics.
+- Don’t drop touch targets below **44px** minimum; prefer **56px** on the d-pad and primary nav.
+- Don’t stack a second design system on top of these tokens.
+- Don’t run **duplicate** curation heartbeat inside the iframe when **`embed`** is set.

--- a/otef-interactive/frontend/DESIGN.md
+++ b/otef-interactive/frontend/DESIGN.md
@@ -120,7 +120,7 @@ components:
 
 ## Overview
 
-The OTEF Remote Controller is a **mobile-first** phone/tablet UI for the Negev Urban Research Lab wall: pan/zoom, GIS table context, layer visibility and time animation, plus curation. Visual tone is **quiet desert instrumentation**—warm charcoal and stone, **one terracotta** primary (`colors.primary`), matte surfaces, no cyan-on-black or neon glow. **Hebrew is default** (`lang="he"`, `dir="rtl"`); a compact **Hebrew | English** toggle in the header switches locale and mirrored layout (logical CSS). **Three bottom tabs**—Navigation, Layers, Curation—replace scattered entry points; Layers is a **full-height scrollable panel** (not a draggable bottom sheet) with **no loss** of grouping, toggles, animation chips, pack/processed behaviors, or OTEFDataContext wiring. **Curation** embeds same-origin `curation.html` in an iframe; parent owns the **single Supabase heartbeat**; embedded app skips duplicate init when an **embed flag** (e.g. `?embed=1`) is present—see implementation plan Task 7. **Layer row labels** use `formatLayerLabelForDisplay` in **`src/shared/layer-name-utils.js`** (underscores/hyphen noise → spaces for display only; canonical ids and `fullLayerIds` unchanged). **Switching away from the Layers tab** does not clear drill-down: reopening **Layers** shows the same focused pack; the in-panel **Back** control returns to the pack overview.
+The OTEF Remote Controller is a **mobile-first** phone/tablet UI for the Negev Urban Research Lab wall: pan/zoom, GIS table context, layer visibility and time animation, plus curation. Visual tone is **quiet desert instrumentation**—warm charcoal and stone, **one terracotta** primary (`colors.primary`), matte surfaces, no cyan-on-black or neon glow. **Hebrew is default** (`lang="he"`, `dir="rtl"`); a compact **עב / en** header pill (two segments, `role="group"`, `aria-label` from locale) switches locale and mirrored layout (logical CSS). **Three bottom tabs**—Navigation, Layers, Curation—replace scattered entry points; Layers is a **full-height scrollable panel** (not a draggable bottom sheet) with **no loss** of grouping, toggles, animation chips, pack/processed behaviors, or OTEFDataContext wiring. **Curation** embeds same-origin `curation.html` in an iframe; parent owns the **single Supabase heartbeat**; embedded app skips duplicate init when an **embed flag** (e.g. `?embed=1`) is present—see implementation plan Task 7. **Layer row labels** use `formatLayerLabelForDisplay` in **`src/shared/layer-name-utils.js`** (underscores/hyphen noise → spaces for display only; canonical ids and `fullLayerIds` unchanged). **Pack labels / layers:** stable group ids are titled via **`src/remote/layer-pack-display-names.js`** (curated title still comes from `t("curatedGroupLabel")` in locale). **Switching away from the Layers tab** does not clear drill-down: reopening **Layers** shows the same focused pack; the in-panel **Back** control returns to the pack overview.
 
 ## Colors
 
@@ -142,16 +142,32 @@ The OTEF Remote Controller is a **mobile-first** phone/tablet UI for the Negev U
 - **body-md** — Descriptions, status, body UI (16px regular, RTL-friendly line height).
 - **label-sm** — Buttons, chips, counts (~13px medium).
 - **tab-label** — Bottom nav (12px semibold; keep Hebrew strings short).
+- **Locale pill (header)** — Segmented control **עב** (Hebrew) and **en** (English) at **~12px** / medium in **`.remote-locale-btn`**, with **padding** so each segment stays **≥44px** min width/height; group label is localized (`localeGroupAria`), not the short glyphs.
 
 Implementation: **logical properties** (`padding-inline`, `margin-inline`, `inset-inline-*`) so English (`dir="ltr"`) mirrors without one-off overrides.
 
 ## Layout
 
 - **Viewport:** `100dvh`, column flex: **fixed header** → **scrollable `main`** (active tab body) → **fixed bottom nav**; `env(safe-area-inset-*)` on header and nav.
-- **Header:** Title/branding, **locale toggle**, **connection** cluster; **below**, full-width **`#table-switcher`** (existing mount contract unchanged).
+- **Header:** Title/branding, **compact locale pill** (`#remoteLocaleToggle` / `remote-locale-btn`), **connection** cluster; **below**, full-width **`#table-switcher`** (existing mount contract unchanged).
 - **Tab panels:** Three regions, each with **`data-remote-tab`** set to **`navigation`**, **`layers`**, or **`curation`** (exact attribute/value names are CI contracts—keep in sync with `html-entrypoint-contract`). Only one panel visible at a time; **Layers** hosts list + **panel header** (title + **active layer count**). **Curation** panel holds **iframe** (`title` localized); **do not** tear down iframe on tab switches unless memory forces it.
 - **Navigation tab:** D-pad, nipplejs joystick, zoom slider + step controls (existing behavior/throttle preserved).
+
+### Navigation tab panel (controller)
+
+This is the **main-area** body for the Navigation tab (`#remote-panel-navigation` / `#navigationSection`) — not the **footer** tab bar (`bottom-nav`).
+
+- **Panel chrome:** Use `--nav-panel-padding-block-start` and `--nav-panel-padding-block-end` (default 12px / 16px) plus `env(safe-area-inset-bottom)` on the bottom panel padding. Horizontal inset follows `--spacing-unit` (maps from `spacing.md`).
+- **Card inset:** The pan/zoom block uses `--nav-panel-section-padding-block` and `--nav-panel-section-padding-inline` (12px / 16px) so the `control-section` does not add extra vertical air.
+- **Vertical distribution (portrait):** `.navigation-panel-stack` is **`flex: 1`** so it fills the tab body; **`.navigation-group--zoom`** uses **`margin-block-start: auto`** so the pan/joystick cluster stays toward the **top** and the zoom block toward the **bottom**, with spare height absorbed between them (not an empty band below zoom). **`--nav-panel-group-gap`** still sets the minimum step between the two groups; pan/zoom inner groups use **`gap: --space-xs`** for label-to-control rhythm.
+- **Groups:** Pan (D-pad + joystick) and zoom (readout, slider, ±) use compact **section labels** (`navPanGroupLabel` / `navZoomGroupLabel` in `remote-locale.js`, ~11px uppercase muted). `.zoom-controls` does not add a second top margin (gap owns the rhythm).
+- **D-pad size (portrait):** **`--nav-panel-dpad-size`** = `min(max(200px, 42dvh), min(260px, 55dvh))` so the pad grows modestly on tall narrow viewports while staying within the band; scoped to `#navigationSection .dpad` so global responsive `.dpad` tweaks do not fight it. **Short landscape:** **`--nav-panel-dpad-size-landscape-short`** (160px) plus **`margin-block-start: 0`** on the zoom group restores the side-by-side row layout.
+- **D-pad column:** In this tab only, **`#navigationSection .dpad-container`** has **`margin-block: 0`** so spacing comes from group/stack gaps, not duplicate vertical margins on the wrapper.
+- **Landscape (short):** In `@media (orientation: landscape) and (max-height: 500px)`, the stack becomes a **row** (wrap): pan stays compact left/center, zoom flexes in reading direction; navigation D-pad uses **`--nav-panel-dpad-size-landscape-short`**; panel top/bottom padding tightens. Footer tab bar rules are unchanged.
+- **Touch:** D-pad buttons and zoom ± stay at `min-height` / `min-width` from `--touch-target-size` (≥44px, prefer 56px); joystick container keeps a ≥44px minimum hit box.
+
 - **Layers tab:** Full-page list; same actions as current sheet (groups, chevrons, row toggles, pack/processed rows, animation chips).
+  - Superseded for remote layers UX by 'Layers panel (chosen mockup: Variant C sharpened)' until Task 7 aligns implementation.
 - **Touch:** Prefer **`spacing.touch` (56px)** on pad, zoom, and nav targets; 8–16px gaps between hit areas.
 
 ## Elevation & Depth
@@ -178,6 +194,25 @@ Implementation: **logical properties** (`padding-inline`, `margin-inline`, `inse
 - **supporting-text** — Tertiary copy: **`ink-subtle`** + **`label-sm`**.
 
 Map tokens to CSS custom properties (e.g. `--color-canvas`, `--color-primary`, `--nav-height`) in **`css/remote-styles.css`**; markup lives in **`remote-controller.html`** per Tasks 3–4.
+
+## Layers panel (chosen mockup: Variant C sharpened)
+
+Implementation and the refreshed static comp follow **`docs/superpowers/plans/2026-04-22-otef-remote-ux-followup.md`** — **Sharpened Variant C** contract (not the original C mockup alone until aligned).
+
+- **Overview:** pack selection uses **pack cards in a horizontal strip** (hybrid of full cards vs. tiny chips — readable titles and actions, not icon-only slivers).
+- **Primary mockup:** [`../../docs/superpowers/mockups/otef-remote-layers-variant-c.html`](../../docs/superpowers/mockups/otef-remote-layers-variant-c.html) · **Hub:** [`../../docs/superpowers/mockups/otef-remote-layers-mockups.html`](../../docs/superpowers/mockups/otef-remote-layers-mockups.html)
+- **Show/hide all (current pack):** **One** compact control — **switch (track + thumb)** *or* a single state pill (not two buttons) — for **all layers in the selected pack**; keep this row **separate** from the tile grid with **≥12px** gap to the first tile row; do not place the **animation** control beside this row.
+- **Layer tiles:** Focused pack shows layers in a **compact tile grid** (wrap, minimum tile width) for density without an endless vertical list; keep **`layer-row`** / raised-surface language where tiles map to “cards.”
+- **Activation:** **Click the layer tile** toggles/selects the layer; **no** row-level on/off control beside the tile. **Off** (neither on-map nor selected), **on-map (non-primary)**, and **primary selected** are visually distinct: **off** = muted/dashed/lower opacity; **on-map** = solid border + full opacity; **selected** = strongest ring/background. **Animation-capable** layers: **separate** control, **min ~44px** hit target on the control only, **bottom-end** of the tile; mockup shows at least one tile with and one without.
+- **Pack selector:** Titles **compact and readable** — no default **ellipsis** on pack names. **Horizontal** strip: **no visible scrollbar**, **no** prev/next **arrow** buttons; **edge fades** + **touch scroll**; optional “גלילה אופקית” / “Swipe horizontally” hint; **scroll snap** allowed — not a vertical pack list.
+- **Counts (subtle):** **Per pack** (selected pack) **e.g. `4/7` active** near the pack label; **overall** “layers on” **e.g. `12 שכבות פעילות` / `12 layers on`** in the header near title or lamp, muted, not a loud badge.
+- **RTL / LTR:** One static comp should show **two mini phone shells** side-by-side (**HE** `dir="rtl"` + **EN** `dir="ltr"`) so mirroring is reviewable.
+
+**Scroll / shell:** Keep **`#layerSheet`** as the full-height layers host; **pack strip** scrolls horizontally when needed; **layer tile grid** is the primary scroll region inside the focused-pack area (vertical overflow only if the grid exceeds the viewport—prefer density so this is rare). Align `#layerPanelContent` / `.sheet-content` rules in **`remote-styles.css`** with these regions (no footer tab bar changes for layers density).
+
+## Workshop / curation embed
+
+When **`curation.html`** is loaded in an iframe with **`?embed=1`** (or `embed=true`), an inline script adds **`html.curation-embed`**. In that mode the top **`.curation-header`** is hidden so the full chrome stays on the parent remote shell; the standalone page keeps the full header. Submissions has an icon-only **refresh** control (**`#curationSubmissionsRefresh`**) in the section toolbar row (same data reload as **`#curationRefresh`**).
 
 ## Do's and Don'ts
 

--- a/otef-interactive/frontend/css/remote-styles.css
+++ b/otef-interactive/frontend/css/remote-styles.css
@@ -1381,44 +1381,44 @@ body.otef-remote-shell {
   padding-block-end: calc(6px + 40px + 6px);
 }
 
-/* Off: recessed control — same 2px border weight as on */
+/* Off: raised chip — pressable (inactive stays visually subordinate to .is-on) */
 .layer-tile.is-off {
   opacity: 1;
   border: 2px solid var(--color-border-strong);
   color: var(--color-ink-muted);
-  background: var(--color-surface);
-  box-shadow: var(--shadow-pressed-terracotta), var(--shadow-pressed-inset),
-    0 1px 0 rgba(245, 240, 234, 0.07);
+  background: var(--color-surface-raised);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 1px 0 rgba(245, 240, 234, 0.06), 0 2px 5px rgba(10, 8, 6, 0.32);
 }
 
 .layer-tile.is-off:hover {
-  background: var(--color-surface-raised);
+  background: color-mix(in srgb, var(--color-surface-raised) 88%, var(--color-ink) 12%);
   border-color: var(--color-border);
-  box-shadow: inset 0 2px 5px rgba(10, 8, 6, 0.18),
-    inset 0 1px 0 rgba(245, 240, 234, 0.08), 0 1px 0 rgba(245, 240, 234, 0.09);
+  color: var(--color-ink);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 1px 0 rgba(245, 240, 234, 0.08), 0 3px 8px rgba(10, 8, 6, 0.38);
 }
 
 .layer-tile.is-off:active:not(:focus-visible) {
   transform: scale(0.98);
-  box-shadow: inset 0 3px 8px rgba(10, 8, 6, 0.28),
-    inset 0 1px 0 rgba(245, 240, 234, 0.05);
+  box-shadow: inset 0 2px 4px rgba(10, 8, 6, 0.35), var(--shadow-pressed-inset);
 }
 
-/* On (layer active): green family; visible / primary ramp emphasis below */
+/* On (layer active): green family — clearly stronger / more “on” than .is-off */
 .layer-tile.is-on {
   opacity: 1;
-  border: 2px solid rgba(122, 155, 122, 0.5);
-  background: rgba(122, 155, 122, 0.08);
+  border: 2px solid rgba(122, 155, 122, 0.55);
+  background: rgba(122, 155, 122, 0.1);
   color: var(--color-ink);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06),
-    0 1px 3px rgba(10, 8, 6, 0.22);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 0 0 1px rgba(122, 155, 122, 0.12), 0 2px 6px rgba(10, 8, 6, 0.28);
 }
 
 .layer-tile.is-on:hover {
-  background: rgba(122, 155, 122, 0.11);
-  border-color: rgba(122, 155, 122, 0.58);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08),
-    0 2px 6px rgba(10, 8, 6, 0.2);
+  background: rgba(122, 155, 122, 0.13);
+  border-color: rgba(122, 155, 122, 0.62);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 0 0 1px rgba(122, 155, 122, 0.18), 0 3px 8px rgba(10, 8, 6, 0.24);
 }
 
 .layer-tile.is-on:active:not(:focus-visible) {
@@ -1427,27 +1427,54 @@ body.otef-remote-shell {
     inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
-/* On-map visible + last-activated: stronger green (Variant C; no terracotta) */
-.layer-tile.is-on.is-visible,
-.layer-tile.is-on.layer-tile--primary {
-  border-color: rgba(122, 155, 122, 0.72);
+/* Non-primary, on: even “halo” ring (map-visible in list; Variant C; no terracotta) */
+.layer-tile.is-on.is-visible {
+  border: 2px solid rgba(122, 155, 122, 0.68);
   background: rgba(122, 155, 122, 0.11);
   box-shadow: 0 0 0 1px rgba(122, 155, 122, 0.32),
     inset 0 1px 0 rgba(255, 255, 255, 0.07), 0 2px 5px rgba(10, 8, 6, 0.18);
 }
 
-.layer-tile.is-on.is-visible:hover,
-.layer-tile.is-on.layer-tile--primary:hover {
+.layer-tile.is-on.is-visible:hover {
   background: rgba(122, 155, 122, 0.14);
   border-color: rgba(122, 155, 122, 0.78);
   box-shadow: 0 0 0 1px rgba(122, 155, 122, 0.38),
     inset 0 1px 0 rgba(255, 255, 255, 0.09), 0 2px 7px rgba(10, 8, 6, 0.2);
 }
 
-.layer-tile.is-on.is-visible:active:not(:focus-visible),
-.layer-tile.is-on.layer-tile--primary:active:not(:focus-visible) {
+.layer-tile.is-on.is-visible:active:not(:focus-visible) {
   box-shadow: inset 0 2px 8px rgba(10, 8, 6, 0.22),
     0 0 0 1px rgba(122, 155, 122, 0.28);
+}
+
+/* Primary (focused row): distinct from .is-visible — start-edge bar + flatter face, no outer ring */
+.layer-tile.is-on.layer-tile--primary {
+  border: 2px solid rgba(122, 155, 122, 0.52);
+  border-inline-start: 4px solid rgba(90, 128, 90, 0.95);
+  background: linear-gradient(
+    to bottom,
+    rgba(122, 155, 122, 0.2) 0%,
+    rgba(122, 155, 122, 0.09) 100%
+  );
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 2px 5px rgba(10, 8, 6, 0.2);
+}
+
+.layer-tile.is-on.layer-tile--primary:hover {
+  border-color: rgba(122, 155, 122, 0.62);
+  border-inline-start-color: rgba(78, 118, 78, 0.98);
+  background: linear-gradient(
+    to bottom,
+    rgba(122, 155, 122, 0.24) 0%,
+    rgba(122, 155, 122, 0.12) 100%
+  );
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 2px 7px rgba(10, 8, 6, 0.18);
+}
+
+.layer-tile.is-on.layer-tile--primary:active:not(:focus-visible) {
+  box-shadow: inset 0 2px 8px rgba(10, 8, 6, 0.22),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .layer-tile:focus-visible {
@@ -1456,8 +1483,8 @@ body.otef-remote-shell {
 }
 
 .layer-tile.is-off:focus-visible {
-  box-shadow: var(--focus-ring-primary), var(--shadow-pressed-terracotta),
-    var(--shadow-pressed-inset), 0 1px 0 rgba(245, 240, 234, 0.07);
+  box-shadow: var(--focus-ring-primary), inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    0 1px 0 rgba(245, 240, 234, 0.06), 0 2px 5px rgba(10, 8, 6, 0.32);
 }
 
 .layer-tile.is-on:focus-visible {
@@ -1465,10 +1492,42 @@ body.otef-remote-shell {
     0 1px 3px rgba(10, 8, 6, 0.22);
 }
 
-.layer-tile.is-on.is-visible:focus-visible,
-.layer-tile.is-on.layer-tile--primary:focus-visible {
+.layer-tile.is-on.is-visible:focus-visible {
   box-shadow: var(--focus-ring-primary), 0 0 0 1px rgba(122, 155, 122, 0.32),
     inset 0 1px 0 rgba(255, 255, 255, 0.07), 0 2px 5px rgba(10, 8, 6, 0.18);
+}
+
+.layer-tile.is-on.layer-tile--primary:focus-visible {
+  box-shadow: var(--focus-ring-primary), inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 2px 5px rgba(10, 8, 6, 0.2);
+}
+
+/* Workshop pack: same swatch classes as workshop page (omitted when no color). */
+.layer-tile__swatch {
+  flex: 0 0 auto;
+  margin-block-end: 4px;
+}
+
+.curation-published-layer-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border-strong);
+  flex-shrink: 0;
+  box-sizing: border-box;
+}
+
+.curation-submission-swatch-dot {
+  --submission-swatch-split-dir: right;
+  background: linear-gradient(
+    to var(--submission-swatch-split-dir),
+    var(--swatch-primary) 50%,
+    var(--swatch-secondary) 50%
+  );
+}
+
+#remoteMain[dir="rtl"] .curation-submission-swatch-dot {
+  --submission-swatch-split-dir: left;
 }
 
 .layer-tile__label {

--- a/otef-interactive/frontend/css/remote-styles.css
+++ b/otef-interactive/frontend/css/remote-styles.css
@@ -45,8 +45,17 @@
   --font-tab-label: 600 0.75rem/1.2 system-ui, "Segoe UI", "SF Pro Text",
     "Helvetica Neue", "Noto Sans Hebrew", sans-serif;
 
-  /* Fixed bottom tab bar (Task 4) */
+  /* Fixed bottom tab bar (footer tabs — not the Navigation *content* tab) */
   --nav-height: 64px;
+  /* Navigation tab panel: main-area map controls (pan / zoom) — not footer */
+  --nav-panel-padding-block-start: var(--space-sm);
+  --nav-panel-padding-block-end: var(--space-md);
+  --nav-panel-group-gap: var(--space-md);
+  --nav-panel-section-padding-block: var(--space-sm);
+  --nav-panel-section-padding-inline: var(--space-md);
+  /* Portrait navigation D-pad: grows modestly with height (see DESIGN.md). */
+  --nav-panel-dpad-size: min(max(200px, 42dvh), min(260px, 55dvh));
+  --nav-panel-dpad-size-landscape-short: 160px;
   --header-padding-block: var(--space-md);
   --header-padding-inline: var(--space-md);
   --shadow-warm: 0 4px 14px rgba(10, 8, 6, 0.35);
@@ -237,7 +246,7 @@ body.otef-remote-shell {
   min-width: 0;
 }
 
-/* Locale toggle: Task 5 wires behavior; static layout for Task 4 */
+/* Locale toggle: compact עב / en labels; min 44×44 touch targets (padding + min size) */
 .remote-locale-toggle {
   display: inline-flex;
   align-items: center;
@@ -250,12 +259,21 @@ body.otef-remote-shell {
 }
 
 .remote-locale-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
   border: none;
   background: transparent;
   color: var(--color-ink-muted);
   font: var(--font-label-sm);
-  padding-block: 8px;
-  padding-inline: 12px;
+  /* Slightly smaller than label-sm for compact two-letter / “en” glyphs; padding keeps ≥44px */
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.1;
+  letter-spacing: 0.02em;
+  padding-block: 10px;
+  padding-inline: 14px;
   min-width: 44px;
   min-height: 44px;
   border-radius: var(--rounded-pill);
@@ -267,6 +285,11 @@ body.otef-remote-shell {
   background: var(--color-canvas);
   color: var(--color-ink);
   box-shadow: var(--shadow-pressed-inset);
+}
+
+.remote-locale-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring-primary);
 }
 
 .remote-title {
@@ -426,11 +449,15 @@ body.otef-remote-shell {
   padding-block-end: calc(var(--spacing-unit) * 2);
 }
 
-/* Navigation tab: fill main area; center controls (avoids an empty “drawer” band below) */
+/* Navigation tab: fill main; stack pan + zoom with tokenized gaps (no vertical centering dead zone) */
 .remote-tab-panel[data-remote-tab="navigation"]:not([hidden]) {
   display: flex;
   flex-direction: column;
-  padding-block-end: var(--spacing-unit);
+  padding-block-start: var(--nav-panel-padding-block-start);
+  padding-block-end: calc(
+    var(--nav-panel-padding-block-end) + env(safe-area-inset-bottom, 0px)
+  );
+  padding-inline: var(--spacing-unit);
 }
 
 #remote-panel-navigation #navigationSection {
@@ -438,9 +465,71 @@ body.otef-remote-shell {
   min-height: 0;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   margin-block-end: 0;
+  padding-block: var(--nav-panel-section-padding-block);
+  padding-inline: var(--nav-panel-section-padding-inline);
   direction: inherit;
+}
+
+.navigation-panel-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--nav-panel-group-gap);
+  width: 100%;
+  min-height: 0;
+}
+
+/* Consume vertical space: pan cluster stays up, zoom sits low (margin absorbs free space). */
+#remote-panel-navigation .navigation-panel-stack {
+  flex: 1 1 auto;
+}
+
+#remote-panel-navigation .navigation-group--zoom {
+  margin-block-start: auto;
+}
+
+.navigation-group--pan {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.navigation-group--zoom {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-xs);
+}
+
+/* Subtle section labels (Navigation tab only); rhythm from group gap, not extra pad margins */
+#remote-panel-navigation .navigation-group-label {
+  margin: 0;
+  padding: 0;
+  font: var(--font-label-sm);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-ink-subtle);
+  text-align: center;
+  align-self: stretch;
+}
+
+#remote-panel-navigation #navigationSection .dpad {
+  width: var(--nav-panel-dpad-size);
+  height: var(--nav-panel-dpad-size);
+}
+
+#navigationSection .dpad-container {
+  margin-block: 0;
+}
+
+#navigationSection .zoom-controls {
+  margin-block-start: 0;
 }
 
 /* Layers: fixed sheet; no outer scroll padding */
@@ -582,6 +671,9 @@ body.otef-remote-shell {
   justify-content: center;
   touch-action: none;
   user-select: none;
+  /* Hit area: grid cell is primary; min keeps ≥44px if layout changes */
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .joystick-base {
@@ -956,23 +1048,48 @@ body.otef-remote-shell {
   }
 }
 
-/* Landscape orientation adjustments */
+/* Landscape: short viewports — pan + zoom side by side; keep touch sizes */
 @media (orientation: landscape) and (max-height: 500px) {
   .remote-tab-panel[data-remote-tab="navigation"]:not([hidden]) {
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-content: flex-start;
-    gap: var(--spacing-unit);
+    padding-block-start: var(--space-xs);
+    padding-block-end: calc(
+      var(--space-sm) + env(safe-area-inset-bottom, 0px)
+    );
   }
 
   .remote-tab-panel[data-remote-tab="navigation"]:not([hidden]) .control-section {
-    flex: 1;
     margin-block-end: 0;
     min-width: 0;
   }
 
-  .dpad-container {
-    margin: var(--spacing-unit) 0;
+  #remote-panel-navigation .navigation-panel-stack {
+    flex: 0 1 auto;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: center;
+    column-gap: var(--space-md);
+    row-gap: var(--space-sm);
+  }
+
+  #remote-panel-navigation .navigation-group--pan {
+    flex: 0 0 auto;
+  }
+
+  #remote-panel-navigation .navigation-group--zoom {
+    flex: 1 1 15rem;
+    min-width: min(100%, 14rem);
+    max-width: 24rem;
+    margin-block-start: 0;
+  }
+
+  #remote-panel-navigation #navigationSection .dpad-container {
+    margin-block: var(--space-xs);
+  }
+
+  #remote-panel-navigation #navigationSection .dpad {
+    width: var(--nav-panel-dpad-size-landscape-short);
+    height: var(--nav-panel-dpad-size-landscape-short);
   }
 
   .dpad {
@@ -1054,8 +1171,10 @@ body.otef-remote-shell {
 }
 
 .layer-count {
-  font: var(--font-label-sm);
-  color: var(--color-ink-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--color-ink-subtle);
 }
 
 .sheet-content {
@@ -1150,82 +1269,349 @@ body.otef-remote-shell {
 .group-layers--expanded {
   max-height: none;
   overflow: visible;
-  border-block-start: 1px solid var(--border-color);
 }
 
-.group-header--focus {
-  cursor: default;
+.group-layers--tiles {
+  padding-block-start: 0;
 }
 
-.layer-group--focus {
-  margin-bottom: 0;
-}
-
-/* Overview: pack cards */
-.layers-overview {
+/* Focused pack: bulk-visibility row (Variant C: ≥12px gap before tile grid) */
+.focused-pack-toolbar {
   display: flex;
-  flex-direction: column;
-  gap: var(--spacing-unit);
-}
-
-.layer-pack-card {
-  border: 1px solid var(--border-color);
-  border-radius: var(--border-radius);
-  background: var(--bg-tertiary);
-  padding: var(--spacing-unit);
-  display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
   gap: var(--space-sm);
+  margin-block-start: 0;
+  margin-block-end: var(--space-md);
+  padding-block: var(--space-sm) 0;
+  min-height: 44px;
+  border: none;
 }
 
-.layer-pack-card__top {
+.focused-pack-toolbar__label {
+  font: var(--font-label-sm);
+  color: var(--color-ink-muted);
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Layer tile grid (Variant C) */
+.layer-tile-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(7.5rem, 1fr));
+  gap: var(--space-sm);
+  width: 100%;
+}
+
+.layer-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  min-block-size: 6.5rem;
+  padding: var(--space-sm);
+  padding-block-end: calc(6px + 44px + 4px);
+  padding-inline: var(--space-sm);
+  border-radius: var(--rounded-sm);
+  background: var(--color-surface-raised);
+  text-align: center;
+  cursor: pointer;
+  border: 2px solid var(--color-border);
+  -webkit-tap-highlight-color: transparent;
+  transition: border-color 0.2s ease, opacity 0.2s ease, background 0.2s ease;
+}
+
+.layer-tile.is-off {
+  opacity: 0.7;
+  border-style: dashed;
+  color: var(--color-ink-muted);
+  background: var(--color-surface);
+}
+
+/* On-map, not primary: green-tint border (Variant C mockup) */
+.layer-tile.is-on.is-visible {
+  opacity: 1;
+  border-style: solid;
+  border-color: rgba(122, 155, 122, 0.65);
+  background: rgba(122, 155, 122, 0.09);
+  color: var(--color-ink);
+  box-shadow: 0 0 0 1px rgba(122, 155, 122, 0.35);
+}
+
+/* Strongest emphasis: primary (last-activated) enabled tile */
+.layer-tile.is-on.layer-tile--primary {
+  opacity: 1;
+  border-style: solid;
+  border-width: 2px;
+  border-color: var(--color-primary);
+  background: rgba(193, 127, 74, 0.16);
+  color: var(--color-ink);
+  box-shadow: 0 0 0 1px rgba(193, 127, 74, 0.45), var(--shadow-warm);
+}
+
+.layer-tile:hover {
+  background: var(--color-surface);
+}
+
+.layer-tile.is-on.is-visible:hover {
+  background: rgba(122, 155, 122, 0.12);
+}
+
+.layer-tile.is-on.layer-tile--primary:hover {
+  background: rgba(193, 127, 74, 0.22);
+}
+
+.layer-tile:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring-primary);
+}
+
+.layer-tile.is-on.layer-tile--primary:focus-visible {
+  box-shadow: var(--focus-ring-primary), 0 0 0 1px rgba(193, 127, 74, 0.45);
+}
+
+.layer-tile__preview {
+  inline-size: 32px;
+  block-size: 32px;
+  border-radius: 6px;
+  border: 2px solid;
+  flex-shrink: 0;
+  margin-block-end: var(--space-xs);
+}
+
+.layer-tile__label {
+  display: block;
+  width: 100%;
+  font: var(--font-label-sm);
+  line-height: 1.3;
+  color: inherit;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
+  flex: 1 1 auto;
+  padding-inline: 2px;
+}
+
+/* Tile-level animation: icon control only (not “Flow” text) */
+.anim-btn {
+  position: absolute;
+  inset-block-end: 6px;
+  inset-inline-end: 6px;
+  z-index: 1;
+  box-sizing: border-box;
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  min-height: 44px;
+  margin: 0;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 10px;
+  background: var(--color-surface);
+  color: var(--color-ink-subtle);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.anim-btn__glyph {
+  display: block;
+  flex-shrink: 0;
+}
+
+.anim-btn:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.anim-btn.active {
+  border-color: rgba(193, 127, 74, 0.65);
+  background: rgba(193, 127, 74, 0.2);
+  color: var(--color-primary);
+}
+
+.anim-btn.mixed {
+  box-shadow: inset 0 0 0 1px rgba(10, 8, 6, 0.35);
+}
+
+.anim-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring-primary);
+}
+
+/* Inert slot: same footprint as .anim-btn for consistent tile geometry */
+.anim-btn--absent {
+  pointer-events: none;
+  opacity: 0;
+  cursor: default;
+  border: none;
+  background: transparent;
+}
+
+.layer-bulk-visibility {
+  flex-shrink: 0;
+}
+
+/* Variant C: one screen — pack head + edge-faded strip + hint + bulk + grid */
+.layers-variant-c {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding-bottom: 2px;
+}
+
+.layers-pack-head {
   display: flex;
   flex-direction: row;
   align-items: baseline;
   justify-content: space-between;
   gap: var(--space-sm);
-  min-width: 0;
+  margin-block-end: 6px;
+  margin-inline: 2px;
 }
 
-.layer-pack-card__title {
-  font: var(--font-title-sm);
-  color: var(--text-primary);
-  flex: 1;
+.layers-pack-head__label {
+  margin: 0;
+  font: var(--font-label-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-ink-muted);
+  font-size: 0.59rem;
+}
+
+.layers-pack-scroll-hint {
+  font-size: 0.62rem;
+  line-height: 1.35;
+  color: var(--color-ink-subtle);
+  margin: 0 2px 8px;
+  text-align: center;
+  letter-spacing: 0.02em;
+}
+
+.layers-pack-strip-wrap {
   min-width: 0;
+  padding-block: var(--space-xs) 4px;
+  padding-inline: 2px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-canvas);
+}
+
+.layers-pack-strip {
+  margin: 0;
+  padding: 0;
+}
+
+.layers-pack-strip__viewport {
+  position: relative;
+  margin-inline: -4px;
+  padding-inline: 4px;
   overflow: hidden;
-  text-overflow: ellipsis;
 }
 
-.layer-pack-card__actions {
+.layers-pack-strip__edge {
+  position: absolute;
+  inset-block: 0;
+  width: 22px;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.layers-pack-strip__edge--start {
+  inset-inline-start: 0;
+}
+
+.layers-pack-strip__edge--end {
+  inset-inline-end: 0;
+}
+
+#remoteMain[dir="ltr"] .layers-pack-strip__edge--start {
+  background: linear-gradient(
+    90deg,
+    var(--color-canvas) 0%,
+    rgba(18, 16, 14, 0) 100%
+  );
+}
+
+#remoteMain[dir="ltr"] .layers-pack-strip__edge--end {
+  background: linear-gradient(
+    270deg,
+    var(--color-canvas) 0%,
+    rgba(18, 16, 14, 0) 100%
+  );
+}
+
+#remoteMain[dir="rtl"] .layers-pack-strip__edge--start {
+  background: linear-gradient(
+    270deg,
+    var(--color-canvas) 0%,
+    rgba(18, 16, 14, 0) 100%
+  );
+}
+
+#remoteMain[dir="rtl"] .layers-pack-strip__edge--end {
+  background: linear-gradient(
+    90deg,
+    var(--color-canvas) 0%,
+    rgba(18, 16, 14, 0) 100%
+  );
+}
+
+.layers-pack-strip__scroller {
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
+  flex-wrap: nowrap;
   gap: var(--space-sm);
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  padding-block: 4px 8px 10px;
+  padding-inline: 6px 12px;
+  box-sizing: border-box;
 }
 
-.layer-pack-open {
+.layers-pack-strip__scroller::-webkit-scrollbar {
+  display: none;
+}
+
+.pack-chip {
+  flex: 0 0 auto;
+  scroll-snap-align: start;
+  margin: 0;
+  padding: 8px 14px;
+  border-radius: var(--rounded-pill);
   border: 1px solid var(--color-border-strong);
   background: var(--color-surface-raised);
-  color: var(--color-primary);
-  border-radius: var(--rounded-sm);
+  color: var(--color-ink-muted);
   font: var(--font-label-sm);
-  padding-block: 8px;
-  padding-inline: 12px;
-  min-height: 44px;
-  min-width: 44px;
+  font-weight: 600;
+  font-size: 0.78rem;
+  line-height: 1.25;
+  white-space: nowrap;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
-.layer-pack-open:hover {
-  border-color: var(--color-primary);
-}
-
-.layer-pack-open:focus-visible {
+.pack-chip:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring-primary);
+}
+
+.pack-chip--selected {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 1px rgba(193, 127, 74, 0.4);
 }
 
 .layer-item {
@@ -1263,27 +1649,6 @@ body.otef-remote-shell {
   flex: 1;
   font-size: 14px;
   color: var(--text-primary);
-}
-
-.animation-chip {
-  border: 1px solid var(--color-border-strong);
-  background: var(--color-surface);
-  color: var(--color-primary);
-  border-radius: var(--rounded-pill);
-  font: var(--font-label-sm);
-  padding-block: 6px;
-  padding-inline: 10px;
-  cursor: pointer;
-}
-
-.animation-chip.active {
-  background: var(--color-surface-raised);
-  border-color: var(--color-primary);
-  color: var(--color-primary);
-}
-
-.animation-chip.mixed {
-  box-shadow: inset 0 0 0 1px rgba(10, 10, 15, 0.35);
 }
 
 /* Toggle Styles for Sheet */

--- a/otef-interactive/frontend/css/remote-styles.css
+++ b/otef-interactive/frontend/css/remote-styles.css
@@ -1,5 +1,4 @@
-/* OTEF Remote Controller Styles
-   Mobile-first responsive design with dark theme */
+/* OTEF Remote Controller — Negev theme (DESIGN.md tokens), mobile-first shell */
 
 * {
   margin: 0;
@@ -8,38 +7,193 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+/* DESIGN.md → CSS variables */
 :root {
-  --bg-primary: #0a0a0f;
-  --bg-secondary: #151520;
-  --bg-tertiary: #1e1e2e;
-  --accent-primary: #00d4ff;
-  --accent-secondary: #00a8cc;
-  --text-primary: #ffffff;
-  --text-secondary: #b0b0c0;
-  --text-muted: #707080;
-  --border-color: #2a2a3a;
-  --success-color: #00ff88;
-  --warning-color: #ffaa00;
-  --error-color: #ff4444;
-  --touch-target-size: 56px;
-  --spacing-unit: 16px;
-  --border-radius: 12px;
+  --color-primary: #c17f4a;
+  --color-primary-hover: #d4925e;
+  --color-on-primary: #141210;
+  --color-canvas: #12100e;
+  --color-surface: #1c1917;
+  --color-surface-raised: #262320;
+  --color-ink: #f5f0ea;
+  --color-ink-muted: #bfb6ab;
+  --color-ink-subtle: #8c847a;
+  --color-border: #3d3834;
+  --color-border-strong: #4a4540;
+  --color-success: #7a9b7a;
+  --color-warning: #d4a85c;
+  --color-danger: #b85c5c;
+  --color-overlay-scrim: #0a0908;
+
+  --rounded-sm: 8px;
+  --rounded-md: 12px;
+  --rounded-lg: 16px;
+  --rounded-pill: 9999px;
+
+  --space-xs: 8px;
+  --space-sm: 12px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-touch: 56px;
+
+  --font-title-sm: 600 1.125rem/1.3 system-ui, "Segoe UI", "SF Pro Text",
+    "Helvetica Neue", sans-serif;
+  --font-body-md: 400 1rem/1.5 system-ui, "Segoe UI", "SF Pro Text",
+    "Helvetica Neue", "Noto Sans Hebrew", sans-serif;
+  --font-label-sm: 500 0.8125rem/1.4 system-ui, "Segoe UI", "SF Pro Text",
+    "Helvetica Neue", "Noto Sans Hebrew", sans-serif;
+  --font-tab-label: 600 0.75rem/1.2 system-ui, "Segoe UI", "SF Pro Text",
+    "Helvetica Neue", "Noto Sans Hebrew", sans-serif;
+
+  /* Fixed bottom tab bar (Task 4) */
+  --nav-height: 64px;
+  --header-padding-block: var(--space-md);
+  --header-padding-inline: var(--space-md);
+  --shadow-warm: 0 4px 14px rgba(10, 8, 6, 0.35);
+  --shadow-pressed-inset: inset 0 1px 0 rgba(245, 240, 234, 0.06);
+  --shadow-pressed-terracotta: inset 0 2px 4px rgba(10, 8, 6, 0.25);
+  --focus-ring-primary: 0 0 0 2px rgba(193, 127, 74, 0.35);
+
   --transition-speed: 200ms;
+
+  /* Legacy names used across this file → map to tokens */
+  --bg-primary: var(--color-canvas);
+  --bg-secondary: var(--color-surface);
+  --bg-tertiary: var(--color-surface-raised);
+  --accent-primary: var(--color-primary);
+  --accent-secondary: var(--color-primary-hover);
+  --text-primary: var(--color-ink);
+  --text-secondary: var(--color-ink-muted);
+  --text-muted: var(--color-ink-subtle);
+  --border-color: var(--color-border);
+  --success-color: var(--color-success);
+  --warning-color: var(--color-warning);
+  --error-color: var(--color-danger);
+  --touch-target-size: var(--space-touch);
+  --spacing-unit: var(--space-md);
+  --border-radius: var(--rounded-md);
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
-    system-ui, sans-serif;
-  background: var(--bg-primary);
-  color: var(--text-primary);
+  font-family: system-ui, "Segoe UI", "SF Pro Text", "Helvetica Neue",
+    "Noto Sans Hebrew", sans-serif;
+  background: var(--color-canvas);
+  color: var(--color-ink);
   overflow: hidden;
+  min-height: 100vh;
+  min-height: 100dvh;
   height: 100vh;
-  height: 100dvh; /* Dynamic viewport height for mobile */
+  height: 100dvh;
   display: flex;
   flex-direction: column;
   touch-action: manipulation;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Remote controller only: LTR “canvas” for chrome so html[dir] does not pull layout. */
+body.otef-remote-shell {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
+/*
+ * #table-switcher: mount for table-switcher.js (id + redirect contract). Intentionally
+ * off-canvas in this remote shell (Task 4) — same as HTML note; not a layout regression.
+ * To show: override `display` here (or a wrapper class) without removing the node.
+ */
+#table-switcher {
+  display: none;
+}
+
+/* Shell chrome: LTR layout always (locale only changes text, not left/right). */
+.remote-header,
+.remote-bottom-nav {
+  direction: ltr;
+  unicode-bidi: isolate;
+}
+
+/* Bottom tab bar (Tablist) */
+.remote-bottom-nav {
+  flex-shrink: 0;
+  min-height: var(--nav-height);
+  box-sizing: border-box;
+  display: flex;
+  align-items: stretch;
+  justify-content: space-around;
+  gap: var(--space-xs);
+  padding-block: var(--space-sm);
+  padding-inline: var(--space-sm);
+  padding-block-end: calc(var(--space-sm) + env(safe-area-inset-bottom, 0px));
+  background: var(--color-surface);
+  color: var(--color-ink-muted);
+  border-block-start: 1px solid var(--color-border);
+  box-shadow: 0 -1px 0 rgba(10, 8, 6, 0.2);
+  z-index: 40;
+}
+
+.remote-bottom-nav__tab {
+  flex: 1;
+  min-width: 0;
+  max-width: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding-block: var(--space-xs);
+  padding-inline: var(--space-xs);
+  margin: 0;
+  border: none;
+  border-radius: var(--rounded-md);
+  background: transparent;
+  color: var(--color-ink-subtle);
+  font: var(--font-tab-label);
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: color var(--transition-speed) ease, background var(--transition-speed) ease;
+}
+
+.remote-bottom-nav__tab .remote-bottom-nav__icon {
+  display: flex;
+  color: currentColor;
+  opacity: 0.85;
+}
+
+.remote-bottom-nav__tab.is-active {
+  color: var(--color-primary);
+  background: rgba(193, 127, 74, 0.12);
+}
+
+.remote-bottom-nav__tab.is-active .remote-bottom-nav__icon {
+  opacity: 1;
+}
+
+.remote-bottom-nav__tab:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring-primary);
+}
+
+.remote-bottom-nav__label {
+  text-align: center;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+/* Screen-reader only */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* Match Leaflet basemap background to typical tile edge color to hide seams */
@@ -49,103 +203,167 @@ body {
 
 /* Header */
 .remote-header {
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border-color);
-  padding: var(--spacing-unit);
+  background: var(--color-surface);
+  color: var(--color-ink);
+  border-block-end: 1px solid var(--color-border);
+  padding-block-start: calc(
+    var(--header-padding-block) + env(safe-area-inset-top, 0px)
+  );
+  padding-block-end: var(--header-padding-block);
+  padding-inline: var(--header-padding-inline);
   flex-shrink: 0;
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
+  z-index: 50;
 }
 
-.header-content {
+.header-top {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: var(--space-sm);
   max-width: 100%;
+  flex-wrap: wrap;
+  row-gap: var(--space-xs);
+  width: 100%;
+}
+
+.header-end {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+/* Locale toggle: Task 5 wires behavior; static layout for Task 4 */
+.remote-locale-toggle {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--rounded-pill);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-raised);
+  padding: 2px;
+  flex-shrink: 0;
+  gap: 0;
+}
+
+.remote-locale-btn {
+  border: none;
+  background: transparent;
+  color: var(--color-ink-muted);
+  font: var(--font-label-sm);
+  padding-block: 8px;
+  padding-inline: 12px;
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: var(--rounded-pill);
+  cursor: pointer;
+  transition: color var(--transition-speed) ease, background var(--transition-speed) ease;
+}
+
+.remote-locale-btn.is-active {
+  background: var(--color-canvas);
+  color: var(--color-ink);
+  box-shadow: var(--shadow-pressed-inset);
 }
 
 .remote-title {
-  font-size: 20px;
-  font-weight: 600;
-  letter-spacing: -0.5px;
-  color: var(--accent-primary);
-  text-transform: uppercase;
-  letter-spacing: 2px;
+  font: var(--font-title-sm);
+  letter-spacing: -0.01em;
+  color: var(--color-ink);
+  text-transform: none;
 }
 
 .curation-link {
-  padding: 8px 12px;
-  border-radius: var(--border-radius);
-  background: var(--bg-tertiary);
-  color: var(--accent-primary);
-  font-size: 14px;
+  padding-block: var(--space-xs);
+  padding-inline: var(--space-sm);
+  border-radius: var(--rounded-md);
+  background: var(--color-surface-raised);
+  color: var(--color-primary);
+  font: var(--font-label-sm);
   text-decoration: none;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color-border);
+  white-space: nowrap;
 }
 
 .curation-link:hover {
-  background: var(--bg-secondary);
-  border-color: var(--accent-primary);
+  background: var(--color-surface);
+  border-color: var(--color-primary-hover);
+  color: var(--color-primary-hover);
 }
 
-/* Table Switcher */
+/* Table switcher (injected UI): spacing for when #table-switcher is displayed */
 .table-switcher {
-  margin-top: 8px;
+  margin-block-start: var(--space-xs);
 }
 
 .table-select {
-  padding: 8px 12px;
-  border: 1px solid var(--border-color);
-  border-radius: var(--border-radius);
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-  font-size: 14px;
+  padding-block: var(--space-xs);
+  padding-inline: var(--space-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-md);
+  background: var(--color-surface-raised);
+  color: var(--color-ink);
+  font: var(--font-label-sm);
   cursor: pointer;
-  min-width: 150px;
-  width: 100%;
-  transition: all var(--transition-speed) ease;
+  min-inline-size: 150px;
+  inline-size: 100%;
+  transition: border-color var(--transition-speed) ease,
+    background var(--transition-speed) ease;
 }
 
 .table-select:hover {
-  border-color: var(--accent-primary);
-  background: var(--bg-secondary);
+  border-color: var(--color-primary);
+  background: var(--color-surface);
 }
 
 .table-select:focus {
   outline: none;
-  border-color: var(--accent-primary);
-  box-shadow: 0 0 0 2px rgba(0, 212, 255, 0.2);
+  border-color: var(--color-primary);
+  box-shadow: var(--focus-ring-primary);
 }
 
 .connection-status {
   display: flex;
+  flex-direction: row-reverse;
   align-items: center;
-  gap: 8px;
-  font-size: 14px;
+  gap: 6px;
+  font: var(--font-label-sm);
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.header-end .status-text {
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .status-indicator {
-  width: 10px;
-  height: 10px;
+  inline-size: 10px;
+  block-size: 10px;
   border-radius: 50%;
-  background: var(--text-muted);
-  transition: all var(--transition-speed) ease;
+  background: var(--color-ink-subtle);
+  transition: background var(--transition-speed) ease;
   animation: pulse 2s infinite;
 }
 
 .status-indicator.connected {
-  background: var(--success-color);
+  background: var(--color-success);
   animation: pulse 2s infinite;
-  box-shadow: 0 0 8px var(--success-color);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
 }
 
 .status-indicator.disconnected {
-  background: var(--error-color);
+  background: var(--color-danger);
   animation: none;
 }
 
 .status-indicator.connecting {
-  background: var(--warning-color);
+  background: var(--color-warning);
   animation: pulse 1s infinite;
 }
 
@@ -160,45 +378,136 @@ body {
 }
 
 .status-text {
-  color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 500;
+  color: var(--color-ink-muted);
+  font: var(--font-label-sm);
 }
 
-/* Main content */
+/* Main: scrolls between header and bottom nav; dir from locale (set in remote-locale). */
 .remote-main {
   flex: 1;
+  min-block-size: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  unicode-bidi: isolate;
+}
+
+.remote-tab-panels {
+  flex: 1;
+  min-block-size: 0;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.remote-tab-panel {
+  flex: 1;
+  min-block-size: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/*
+ * [hidden] relies on UA display:none, but this file’s `.remote-tab-panel { display:flex }`
+ * wins the cascade and keeps inactive panels in the flex stack. Force them out of layout.
+ */
+.remote-tab-panel[hidden] {
+  display: none;
+}
+
+/* Visible panel: [hidden] removes from layout (native) */
+.remote-tab-panel:not([hidden]) {
   overflow-y: auto;
   overflow-x: hidden;
-  padding: var(--spacing-unit);
-  padding-bottom: calc(var(--spacing-unit) * 2);
   -webkit-overflow-scrolling: touch;
+  padding-block: var(--spacing-unit);
+  padding-inline: var(--spacing-unit);
+  padding-block-end: calc(var(--spacing-unit) * 2);
+}
+
+/* Navigation tab: fill main area; center controls (avoids an empty “drawer” band below) */
+.remote-tab-panel[data-remote-tab="navigation"]:not([hidden]) {
+  display: flex;
+  flex-direction: column;
+  padding-block-end: var(--spacing-unit);
+}
+
+#remote-panel-navigation #navigationSection {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-block-end: 0;
+  direction: inherit;
+}
+
+/* Layers: fixed sheet; no outer scroll padding */
+.remote-tab-panel[data-remote-tab="layers"]:not([hidden]) {
+  padding: 0;
+  overflow: visible;
+}
+
+.remote-tab-panel[data-remote-tab="curation"]:not([hidden]) {
+  padding: 0;
+  overflow: hidden;
+}
+
+.remote-layer-host {
+  flex: 1;
+  min-block-size: 0;
+  min-height: 0;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing-unit);
+  padding-block-end: calc(var(--spacing-unit) + env(safe-area-inset-bottom, 0px));
+}
+
+/* Workshop / curation embed: same-origin iframe fills tab (static node — state kept on tab switch) */
+.remote-curation-surface {
+  flex: 1;
+  min-block-size: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+.remote-curation-frame {
+  flex: 1;
+  width: 100%;
+  min-block-size: 0;
+  min-height: 0;
+  border: none;
+  background: var(--color-surface);
 }
 
 .control-section {
-  margin-bottom: calc(var(--spacing-unit) * 2);
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--border-radius);
+  margin-block-end: calc(var(--spacing-unit) * 2);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-md);
   padding: var(--spacing-unit);
 }
 
 .section-title {
-  font-size: 14px;
-  font-weight: 600;
+  font: var(--font-label-sm);
   text-transform: uppercase;
-  letter-spacing: 1px;
-  color: var(--text-secondary);
-  margin-bottom: var(--spacing-unit);
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--border-color);
+  letter-spacing: 0.04em;
+  color: var(--color-ink-muted);
+  margin-block-end: var(--spacing-unit);
+  padding-block-end: var(--space-xs);
+  border-block-end: 1px solid var(--color-border);
 }
 
 /* Directional pad */
 .dpad-container {
   display: flex;
   justify-content: center;
-  margin: calc(var(--spacing-unit) * 1.5) 0;
+  margin-block: calc(var(--spacing-unit) * 1.5);
 }
 
 .dpad {
@@ -230,10 +539,11 @@ body {
 
 .dpad-button:active,
 .dpad-button.active {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
+  background: var(--color-primary);
+  border-color: var(--color-primary-hover);
+  color: var(--color-on-primary);
   transform: scale(0.95);
-  box-shadow: 0 0 20px rgba(0, 212, 255, 0.4);
+  box-shadow: var(--shadow-pressed-terracotta), var(--shadow-pressed-inset);
 }
 
 .dpad-button svg {
@@ -286,58 +596,57 @@ body {
 }
 
 .joystick-container.active .joystick-base {
-  border-color: var(--accent-primary);
+  border-color: var(--color-primary);
   opacity: 1;
-  box-shadow: 0 0 20px rgba(0, 212, 255, 0.4);
+  box-shadow: var(--shadow-pressed-inset);
 }
 
-/* Nipple.js override styles to match dark theme */
+/* Nipple.js override — Negev / terracotta */
 #joystickZone .back {
-  background: var(--bg-tertiary) !important;
-  border: 2px solid var(--border-color) !important;
+  background: var(--color-surface-raised) !important;
+  border: 2px solid var(--color-border) !important;
 }
 
 #joystickZone .front {
-  background: var(--accent-primary) !important;
-  border: none !important;
-  box-shadow: 0 0 10px rgba(0, 212, 255, 0.6) !important;
+  background: var(--color-primary) !important;
+  border: 1px solid rgba(20, 18, 16, 0.35) !important;
+  box-shadow: var(--shadow-pressed-terracotta) !important;
 }
 
 #joystickZone.active .back {
-  border-color: var(--accent-primary) !important;
-  box-shadow: 0 0 20px rgba(0, 212, 255, 0.4) !important;
+  border-color: var(--color-primary) !important;
+  box-shadow: none !important;
 }
 
 /* Zoom controls */
 .zoom-controls {
-  margin-top: var(--spacing-unit);
+  margin-block-start: var(--spacing-unit);
 }
 
 .zoom-display {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 12px;
-  font-size: 14px;
+  margin-block-end: var(--space-sm);
+  font: var(--font-label-sm);
 }
 
 .zoom-label {
-  color: var(--text-secondary);
-  font-weight: 500;
+  color: var(--color-ink-muted);
 }
 
 .zoom-value {
-  color: var(--accent-primary);
+  color: var(--color-primary);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
-  min-width: 30px;
-  text-align: right;
+  min-inline-size: 30px;
+  text-align: end;
 }
 
 .zoom-slider-container {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-sm);
 }
 
 .zoom-slider {
@@ -356,35 +665,40 @@ body {
   appearance: none;
   width: 20px;
   height: 20px;
-  background: var(--accent-primary);
+  background: var(--color-primary);
   border-radius: 50%;
   cursor: pointer;
   transition: all var(--transition-speed) ease;
-  box-shadow: 0 0 0 0 rgba(0, 212, 255, 0.4);
+  border: 1px solid rgba(20, 18, 16, 0.3);
+  box-shadow: 0 1px 2px rgba(10, 8, 6, 0.35);
 }
 
 .zoom-slider::-webkit-slider-thumb:active {
-  transform: scale(1.2);
-  box-shadow: 0 0 0 8px rgba(0, 212, 255, 0.2);
+  transform: scale(1.05);
+  background: var(--color-primary-hover);
+  box-shadow: var(--shadow-pressed-terracotta), var(--shadow-pressed-inset);
 }
 
 .zoom-slider::-moz-range-thumb {
   width: 20px;
   height: 20px;
-  background: var(--accent-primary);
-  border: none;
+  background: var(--color-primary);
+  border: 1px solid rgba(20, 18, 16, 0.3);
   border-radius: 50%;
   cursor: pointer;
   transition: all var(--transition-speed) ease;
+  box-shadow: 0 1px 2px rgba(10, 8, 6, 0.35);
 }
 
 .zoom-slider::-moz-range-thumb:active {
-  transform: scale(1.2);
+  transform: scale(1.05);
+  background: var(--color-primary-hover);
+  box-shadow: var(--shadow-pressed-terracotta), var(--shadow-pressed-inset);
 }
 
 .zoom-buttons {
   display: flex;
-  gap: 8px;
+  gap: var(--space-xs);
 }
 
 .zoom-button {
@@ -407,9 +721,11 @@ body {
 }
 
 .zoom-button:active {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
+  background: var(--color-primary);
+  border-color: var(--color-primary-hover);
+  color: var(--color-on-primary);
   transform: scale(0.95);
+  box-shadow: var(--shadow-pressed-terracotta), var(--shadow-pressed-inset);
 }
 
 /* Layer controls */
@@ -457,21 +773,26 @@ body {
   position: absolute;
   width: 18px;
   height: 18px;
-  background: var(--text-muted);
+  background: var(--color-ink-subtle);
   border-radius: 50%;
-  top: 1px;
-  left: 1px;
-  transition: all var(--transition-speed) ease;
+  inset-block-start: 1px;
+  inset-inline-start: 1px;
+  transition: transform var(--transition-speed) ease,
+    background var(--transition-speed) ease;
 }
 
 .layer-toggle input[type="checkbox"]:checked + .toggle-indicator {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 .layer-toggle input[type="checkbox"]:checked + .toggle-indicator::after {
   transform: translateX(20px);
-  background: var(--text-primary);
+  background: var(--color-ink);
+}
+
+[dir="rtl"] .layer-toggle input[type="checkbox"]:checked + .toggle-indicator::after {
+  transform: translateX(-20px);
 }
 
 .toggle-label {
@@ -507,13 +828,20 @@ body {
 }
 
 .layer-toggle-main input[type="checkbox"]:checked + .toggle-indicator {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 .layer-toggle-main input[type="checkbox"]:checked + .toggle-indicator::after {
   transform: translateX(20px);
-  background: var(--text-primary);
+  background: var(--color-ink);
+}
+
+[dir="rtl"]
+  .layer-toggle-main
+  input[type="checkbox"]:checked
+  + .toggle-indicator::after {
+  transform: translateX(-20px);
 }
 
 /* Animation toggle button */
@@ -539,8 +867,8 @@ body {
 }
 
 .animation-toggle-btn:not(:disabled):hover {
-  border-color: var(--accent-primary);
-  color: var(--accent-primary);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
 .animation-toggle-btn:not(:disabled):active {
@@ -548,20 +876,10 @@ body {
 }
 
 .animation-toggle-btn.active {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
-  color: var(--text-primary);
-  box-shadow: 0 0 15px rgba(0, 212, 255, 0.5);
-  animation: pulse-glow 2s ease-in-out infinite;
-}
-
-@keyframes pulse-glow {
-  0%, 100% {
-    box-shadow: 0 0 15px rgba(0, 212, 255, 0.5);
-  }
-  50% {
-    box-shadow: 0 0 25px rgba(0, 212, 255, 0.8);
-  }
+  background: var(--color-primary);
+  border-color: var(--color-primary-hover);
+  color: var(--color-on-primary);
+  box-shadow: var(--shadow-pressed-terracotta), var(--shadow-pressed-inset);
 }
 
 .animation-toggle-btn svg {
@@ -572,11 +890,8 @@ body {
 /* Warning overlay */
 .warning-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.85);
+  inset: 0;
+  background: rgba(10, 9, 8, 0.78);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   display: flex;
@@ -584,6 +899,9 @@ body {
   justify-content: center;
   z-index: 10000;
   padding: var(--spacing-unit);
+  padding-block-end: calc(
+    var(--spacing-unit) + env(safe-area-inset-bottom, 0px)
+  );
 }
 
 .warning-overlay.hidden {
@@ -591,26 +909,27 @@ body {
 }
 
 .warning-content {
-  background: var(--bg-secondary);
-  border: 2px solid var(--warning-color);
-  border-radius: var(--border-radius);
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--rounded-lg);
   padding: calc(var(--spacing-unit) * 2);
   text-align: center;
-  max-width: 300px;
+  max-inline-size: 300px;
+  box-shadow: var(--shadow-warm);
 }
 
 .warning-icon {
   width: 48px;
   height: 48px;
-  color: var(--warning-color);
-  margin: 0 auto calc(var(--spacing-unit) * 1.5);
+  color: var(--color-warning);
+  margin-block-end: calc(var(--spacing-unit) * 1.5);
+  margin-inline: auto;
   display: block;
 }
 
 .warning-text {
-  color: var(--text-primary);
-  font-size: 15px;
-  line-height: 1.5;
+  color: var(--color-ink);
+  font: var(--font-body-md);
 }
 
 /* Responsive adjustments */
@@ -639,16 +958,17 @@ body {
 
 /* Landscape orientation adjustments */
 @media (orientation: landscape) and (max-height: 500px) {
-  .remote-main {
-    display: flex;
+  .remote-tab-panel[data-remote-tab="navigation"]:not([hidden]) {
     flex-direction: row;
+    flex-wrap: wrap;
+    align-content: flex-start;
     gap: var(--spacing-unit);
-    padding: var(--spacing-unit);
   }
 
-  .control-section {
+  .remote-tab-panel[data-remote-tab="navigation"]:not([hidden]) .control-section {
     flex: 1;
-    margin-bottom: 0;
+    margin-block-end: 0;
+    min-width: 0;
   }
 
   .dpad-container {
@@ -661,61 +981,86 @@ body {
   }
 }
 
-/* Layer Bottom Sheet */
-.layer-sheet {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background: var(--bg-secondary);
-  border-top: 1px solid var(--border-color);
-  border-radius: var(--border-radius) var(--border-radius) 0 0;
-  max-height: 80vh;
-  transform: translateY(calc(100% - 60px));
-  transition: transform 0.3s ease-out;
-  z-index: 1000;
+/* Layers tab panel (full-height; #layerSheet) */
+.layer-panel#layerSheet,
+.layer-panel {
+  position: relative;
+  flex: 1;
+  min-block-size: 0;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--rounded-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-warm);
 }
 
-.layer-sheet.open {
-  transform: translateY(0);
-}
-
-.sheet-handle {
-  width: 40px;
-  height: 4px;
-  background: var(--border-color);
-  border-radius: 2px;
-  margin: 12px auto;
-  cursor: pointer;
-  touch-action: none;
-  flex-shrink: 0;
-}
-
-.sheet-header {
+.layer-panel-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: row;
   align-items: center;
-  padding: 0 var(--spacing-unit) var(--spacing-unit);
-  border-bottom: 1px solid var(--border-color);
+  gap: var(--space-sm);
+  padding-block: var(--space-sm) var(--spacing-unit);
+  padding-inline: var(--spacing-unit);
+  border-block-end: 1px solid var(--color-border);
   flex-shrink: 0;
+}
+
+.layer-panel-back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-inline-size: var(--touch-target-size);
+  min-block-size: var(--touch-target-size);
+  margin: 0;
+  padding: 0;
+  border: none;
+  border-radius: var(--rounded-sm);
+  background: var(--color-surface-raised);
+  color: var(--color-ink);
+  cursor: pointer;
+  flex-shrink: 0;
+  -webkit-tap-highlight-color: transparent;
+  transition: background var(--transition-speed) ease;
+}
+
+.layer-panel-back:hover {
+  background: var(--color-border);
+}
+
+.layer-panel-back:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring-primary);
+}
+
+[dir="ltr"] .layer-panel-back__icon {
+  transform: scaleX(-1);
+}
+
+.layer-panel-header__text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
 }
 
 .sheet-title {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text-primary);
+  font: var(--font-title-sm);
+  color: var(--color-ink);
 }
 
 .layer-count {
-  font-size: 14px;
-  color: var(--text-secondary);
+  font: var(--font-label-sm);
+  color: var(--color-ink-muted);
 }
 
 .sheet-content {
   flex: 1;
+  min-block-size: 0;
   overflow-y: auto;
   padding: var(--spacing-unit);
   -webkit-overflow-scrolling: touch;
@@ -723,8 +1068,8 @@ body {
 
 .sheet-empty {
   text-align: center;
-  color: var(--text-muted);
-  padding: var(--spacing-unit) * 2;
+  color: var(--color-ink-subtle);
+  padding: calc(var(--spacing-unit) * 2);
 }
 
 /* Layer Groups */
@@ -802,6 +1147,87 @@ body {
   border-top: 1px solid var(--border-color);
 }
 
+.group-layers--expanded {
+  max-height: none;
+  overflow: visible;
+  border-block-start: 1px solid var(--border-color);
+}
+
+.group-header--focus {
+  cursor: default;
+}
+
+.layer-group--focus {
+  margin-bottom: 0;
+}
+
+/* Overview: pack cards */
+.layers-overview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-unit);
+}
+
+.layer-pack-card {
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius);
+  background: var(--bg-tertiary);
+  padding: var(--spacing-unit);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.layer-pack-card__top {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-sm);
+  min-width: 0;
+}
+
+.layer-pack-card__title {
+  font: var(--font-title-sm);
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.layer-pack-card__actions {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+}
+
+.layer-pack-open {
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface-raised);
+  color: var(--color-primary);
+  border-radius: var(--rounded-sm);
+  font: var(--font-label-sm);
+  padding-block: 8px;
+  padding-inline: 12px;
+  min-height: 44px;
+  min-width: 44px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.layer-pack-open:hover {
+  border-color: var(--color-primary);
+}
+
+.layer-pack-open:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring-primary);
+}
+
 .layer-item {
   display: flex;
   align-items: center;
@@ -840,20 +1266,20 @@ body {
 }
 
 .animation-chip {
-  border: 1px solid var(--border-color);
-  background: var(--bg-primary);
-  color: var(--text-secondary);
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 600;
-  padding: 4px 10px;
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-primary);
+  border-radius: var(--rounded-pill);
+  font: var(--font-label-sm);
+  padding-block: 6px;
+  padding-inline: 10px;
   cursor: pointer;
 }
 
 .animation-chip.active {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
-  color: var(--text-primary);
+  background: var(--color-surface-raised);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
 }
 
 .animation-chip.mixed {
@@ -883,27 +1309,35 @@ body {
 
 .layer-item .toggle-indicator::after,
 .group-toggle .toggle-indicator::after {
-  content: '';
+  content: "";
   position: absolute;
   width: 18px;
   height: 18px;
-  background: var(--text-muted);
+  background: var(--color-ink-subtle);
   border-radius: 50%;
-  top: 1px;
-  left: 1px;
-  transition: all 0.2s ease;
+  inset-block-start: 1px;
+  inset-inline-start: 1px;
+  transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .layer-item input[type="checkbox"]:checked + .toggle-indicator,
 .group-toggle input[type="checkbox"]:checked + .toggle-indicator {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
 }
 
 .layer-item input[type="checkbox"]:checked + .toggle-indicator::after,
 .group-toggle input[type="checkbox"]:checked + .toggle-indicator::after {
   transform: translateX(20px);
-  background: var(--text-primary);
+  background: var(--color-ink);
+}
+
+[dir="rtl"] .layer-item input[type="checkbox"]:checked + .toggle-indicator::after,
+[dir="rtl"]
+  .group-toggle
+  input[type="checkbox"]:checked
+  + .toggle-indicator::after {
+  transform: translateX(-20px);
 }
 
 /* Accessibility */
@@ -917,7 +1351,10 @@ body {
 /* High contrast mode support */
 @media (prefers-contrast: high) {
   :root {
-    --border-color: #ffffff;
-    --text-secondary: #ffffff;
+    --color-border: #ffffff;
+    --color-border-strong: #ffffff;
+    --color-ink-muted: #ffffff;
+    --border-color: var(--color-border);
+    --text-secondary: var(--color-ink-muted);
   }
 }

--- a/otef-interactive/frontend/css/remote-styles.css
+++ b/otef-interactive/frontend/css/remote-styles.css
@@ -56,8 +56,9 @@
   /* Portrait navigation D-pad: grows modestly with height (see DESIGN.md). */
   --nav-panel-dpad-size: min(max(200px, 42dvh), min(260px, 55dvh));
   --nav-panel-dpad-size-landscape-short: 160px;
-  --header-padding-block: var(--space-md);
-  --header-padding-inline: var(--space-md);
+  /* T28 / U1: compact header; safe-area still on .remote-header */
+  --header-padding-block: 6px;
+  --header-padding-inline: var(--space-sm);
   --shadow-warm: 0 4px 14px rgba(10, 8, 6, 0.35);
   --shadow-pressed-inset: inset 0 1px 0 rgba(245, 240, 234, 0.06);
   --shadow-pressed-terracotta: inset 0 2px 4px rgba(10, 8, 6, 0.25);
@@ -230,10 +231,10 @@ body.otef-remote-shell {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: var(--space-sm);
+  gap: var(--space-xs);
   max-width: 100%;
   flex-wrap: wrap;
-  row-gap: var(--space-xs);
+  row-gap: 4px;
   width: 100%;
 }
 
@@ -246,16 +247,17 @@ body.otef-remote-shell {
   min-width: 0;
 }
 
-/* Locale toggle: compact עב / en labels; min 44×44 touch targets (padding + min size) */
+/* Locale toggle: compact chrome; each control ≥ 44×44 (touch, WCAG) */
 .remote-locale-toggle {
   display: inline-flex;
   align-items: center;
   border-radius: var(--rounded-pill);
   border: 1px solid var(--color-border);
   background: var(--color-surface-raised);
-  padding: 2px;
+  padding: 0;
   flex-shrink: 0;
   gap: 0;
+  box-sizing: border-box;
 }
 
 .remote-locale-btn {
@@ -267,13 +269,12 @@ body.otef-remote-shell {
   background: transparent;
   color: var(--color-ink-muted);
   font: var(--font-label-sm);
-  /* Slightly smaller than label-sm for compact two-letter / “en” glyphs; padding keeps ≥44px */
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   font-weight: 500;
   line-height: 1.1;
-  letter-spacing: 0.02em;
-  padding-block: 10px;
-  padding-inline: 14px;
+  letter-spacing: 0.01em;
+  padding-block: 4px;
+  padding-inline: 8px;
   min-width: 44px;
   min-height: 44px;
   border-radius: var(--rounded-pill);
@@ -449,7 +450,7 @@ body.otef-remote-shell {
   padding-block-end: calc(var(--spacing-unit) * 2);
 }
 
-/* Navigation tab: fill main; stack pan + zoom with tokenized gaps (no vertical centering dead zone) */
+/* Navigation tab: fill main; pan cluster vertically balanced vs zoom (T23) */
 .remote-tab-panel[data-remote-tab="navigation"]:not([hidden]) {
   display: flex;
   flex-direction: column;
@@ -466,10 +467,16 @@ body.otef-remote-shell {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
+  /* Let inner stack grow; avoid extra slab below zoom (pan/zoom use flex) */
   margin-block-end: 0;
   padding-block: var(--nav-panel-section-padding-block);
   padding-inline: var(--nav-panel-section-padding-inline);
   direction: inherit;
+}
+
+/* T23: don’t use default .control-section bottom margin under nav (adds false “air” below zoom) */
+#remote-panel-navigation #navigationSection.control-section {
+  margin-block-end: 0;
 }
 
 .navigation-panel-stack {
@@ -481,13 +488,24 @@ body.otef-remote-shell {
   min-height: 0;
 }
 
-/* Consume vertical space: pan cluster stays up, zoom sits low (margin absorbs free space). */
+/* T23 / U2: pan group grows above zoom; content centered vertically — no extra band between pan and zoom */
 #remote-panel-navigation .navigation-panel-stack {
   flex: 1 1 auto;
+  min-block-size: 0;
+  justify-content: flex-start;
+}
+
+#remote-panel-navigation .navigation-group--pan {
+  flex: 1 1 auto;
+  min-block-size: 0;
+  margin-block: 0;
+  /* Center D-pad + joystick in the space above the zoom row (only stack gap before zoom) */
+  justify-content: center;
 }
 
 #remote-panel-navigation .navigation-group--zoom {
-  margin-block-start: auto;
+  margin-block-start: 0;
+  flex: 0 0 auto;
 }
 
 .navigation-group--pan {
@@ -519,9 +537,25 @@ body.otef-remote-shell {
   align-self: stretch;
 }
 
+/* No reserved row when pan heading copy is empty (navPanGroupLabel) */
+#remote-panel-navigation
+  .navigation-group--pan
+  .navigation-group-label:empty {
+  display: none;
+}
+
 #remote-panel-navigation #navigationSection .dpad {
   width: var(--nav-panel-dpad-size);
   height: var(--nav-panel-dpad-size);
+}
+
+#remote-panel-navigation .dpad-container,
+#remote-panel-navigation .dpad {
+  direction: ltr;
+}
+
+#remote-panel-navigation .joystick-container {
+  direction: ltr;
 }
 
 #navigationSection .dpad-container {
@@ -1039,6 +1073,47 @@ body.otef-remote-shell {
     width: 180px;
     height: 180px;
   }
+
+  /* Pan cluster: centered in stack; zoom row stays full width */
+  #remote-panel-navigation .navigation-panel-stack {
+    gap: var(--space-sm);
+    align-items: center;
+  }
+
+  #remote-panel-navigation .navigation-group--zoom {
+    align-self: stretch;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  /* Use more horizontal room than a fixed rem cap; still respect shell padding */
+  #remote-panel-navigation .navigation-group--pan {
+    width: 100%;
+    max-width: min(100%, calc(100vw - 2.75rem));
+    margin-inline: auto;
+    align-self: center;
+    gap: 6px;
+  }
+
+  #remote-panel-navigation #navigationSection .dpad-container {
+    width: 100%;
+    max-width: min(100%, calc(100vw - 2.75rem));
+    margin-inline: auto;
+  }
+
+  #remote-panel-navigation #navigationSection .dpad {
+    width: min(
+      var(--nav-panel-dpad-size),
+      calc(100vw - 2.75rem),
+      24rem
+    );
+    height: min(
+      var(--nav-panel-dpad-size),
+      calc(100vw - 2.75rem),
+      24rem
+    );
+    max-width: 100%;
+  }
 }
 
 @media (min-width: 768px) {
@@ -1072,8 +1147,12 @@ body.otef-remote-shell {
     row-gap: var(--space-sm);
   }
 
+  /* T23 / U2: row layout; no flex growth / vertical centering (portrait only) */
   #remote-panel-navigation .navigation-group--pan {
     flex: 0 0 auto;
+    min-height: 0;
+    margin-block: 0;
+    justify-content: flex-start;
   }
 
   #remote-panel-navigation .navigation-group--zoom {
@@ -1113,65 +1192,23 @@ body.otef-remote-shell {
   box-shadow: var(--shadow-warm);
 }
 
-.layer-panel-header {
+/* Global active layer count: directly under pack strip (T24; #layerPanelCount) */
+.layers-active-summary {
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--space-sm);
-  padding-block: var(--space-sm) var(--spacing-unit);
-  padding-inline: var(--spacing-unit);
-  border-block-end: 1px solid var(--color-border);
-  flex-shrink: 0;
+  justify-content: flex-end;
+  margin-block-start: var(--space-xs);
+  margin-block-end: var(--space-sm);
+  min-height: 1.25rem;
 }
 
-.layer-panel-back {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-inline-size: var(--touch-target-size);
-  min-block-size: var(--touch-target-size);
-  margin: 0;
-  padding: 0;
-  border: none;
-  border-radius: var(--rounded-sm);
-  background: var(--color-surface-raised);
-  color: var(--color-ink);
-  cursor: pointer;
-  flex-shrink: 0;
-  -webkit-tap-highlight-color: transparent;
-  transition: background var(--transition-speed) ease;
-}
-
-.layer-panel-back:hover {
-  background: var(--color-border);
-}
-
-.layer-panel-back:focus-visible {
-  outline: none;
-  box-shadow: var(--focus-ring-primary);
-}
-
-[dir="ltr"] .layer-panel-back__icon {
-  transform: scaleX(-1);
-}
-
-.layer-panel-header__text {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-sm);
-}
-
-.sheet-title {
-  font: var(--font-title-sm);
-  color: var(--color-ink);
+.layers-variant-c--empty .layers-active-summary {
+  margin-block-end: var(--space-md);
 }
 
 .layer-count {
-  font-size: 0.75rem;
+  font-size: 0.8125rem;
   font-weight: 500;
   line-height: 1.35;
   color: var(--color-ink-subtle);
@@ -1297,12 +1334,24 @@ body.otef-remote-shell {
   min-width: 0;
 }
 
-/* Layer tile grid (Variant C) */
+/* Layer tiles: CSS grid — short labels first (JS order), compact row height, animation control inset */
 .layer-tile-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(7.5rem, 1fr));
-  gap: var(--space-sm);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-auto-rows: min-content;
+  gap: var(--space-xs);
   width: 100%;
+  direction: inherit;
+  /* Pack rows to the start; stretch items so each row shares one height (avoids empty band in shorter cell). */
+  align-content: start;
+  justify-content: start;
+  align-items: stretch;
+}
+
+@media (min-width: 26rem) {
+  .layer-tile-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 .layer-tile {
@@ -1311,57 +1360,94 @@ body.otef-remote-shell {
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  min-block-size: 6.5rem;
-  padding: var(--space-sm);
-  padding-block-end: calc(6px + 44px + 4px);
-  padding-inline: var(--space-sm);
+  width: 100%;
+  min-height: 0;
+  min-block-size: 0;
+  box-sizing: border-box;
+  padding-block: 6px;
+  padding-inline: var(--space-xs);
   border-radius: var(--rounded-sm);
   background: var(--color-surface-raised);
   text-align: center;
   cursor: pointer;
   border: 2px solid var(--color-border);
   -webkit-tap-highlight-color: transparent;
-  transition: border-color 0.2s ease, opacity 0.2s ease, background 0.2s ease;
+  transition: border-color 0.2s ease, opacity 0.2s ease, background 0.2s ease,
+    box-shadow 0.2s ease, transform 0.15s ease;
 }
 
+/* Reserve bottom band only when an animation toggle exists (see layer-sheet-controller). */
+.layer-tile--anim {
+  padding-block-end: calc(6px + 40px + 6px);
+}
+
+/* Off: recessed control — same 2px border weight as on */
 .layer-tile.is-off {
-  opacity: 0.7;
-  border-style: dashed;
+  opacity: 1;
+  border: 2px solid var(--color-border-strong);
   color: var(--color-ink-muted);
   background: var(--color-surface);
+  box-shadow: var(--shadow-pressed-terracotta), var(--shadow-pressed-inset),
+    0 1px 0 rgba(245, 240, 234, 0.07);
 }
 
-/* On-map, not primary: green-tint border (Variant C mockup) */
-.layer-tile.is-on.is-visible {
+.layer-tile.is-off:hover {
+  background: var(--color-surface-raised);
+  border-color: var(--color-border);
+  box-shadow: inset 0 2px 5px rgba(10, 8, 6, 0.18),
+    inset 0 1px 0 rgba(245, 240, 234, 0.08), 0 1px 0 rgba(245, 240, 234, 0.09);
+}
+
+.layer-tile.is-off:active:not(:focus-visible) {
+  transform: scale(0.98);
+  box-shadow: inset 0 3px 8px rgba(10, 8, 6, 0.28),
+    inset 0 1px 0 rgba(245, 240, 234, 0.05);
+}
+
+/* On (layer active): green family; visible / primary ramp emphasis below */
+.layer-tile.is-on {
   opacity: 1;
-  border-style: solid;
-  border-color: rgba(122, 155, 122, 0.65);
-  background: rgba(122, 155, 122, 0.09);
+  border: 2px solid rgba(122, 155, 122, 0.5);
+  background: rgba(122, 155, 122, 0.08);
   color: var(--color-ink);
-  box-shadow: 0 0 0 1px rgba(122, 155, 122, 0.35);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 1px 3px rgba(10, 8, 6, 0.22);
 }
 
-/* Strongest emphasis: primary (last-activated) enabled tile */
+.layer-tile.is-on:hover {
+  background: rgba(122, 155, 122, 0.11);
+  border-color: rgba(122, 155, 122, 0.58);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 2px 6px rgba(10, 8, 6, 0.2);
+}
+
+.layer-tile.is-on:active:not(:focus-visible) {
+  transform: scale(0.98);
+  box-shadow: inset 0 2px 6px rgba(10, 8, 6, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+/* On-map visible + last-activated: stronger green (Variant C; no terracotta) */
+.layer-tile.is-on.is-visible,
 .layer-tile.is-on.layer-tile--primary {
-  opacity: 1;
-  border-style: solid;
-  border-width: 2px;
-  border-color: var(--color-primary);
-  background: rgba(193, 127, 74, 0.16);
-  color: var(--color-ink);
-  box-shadow: 0 0 0 1px rgba(193, 127, 74, 0.45), var(--shadow-warm);
+  border-color: rgba(122, 155, 122, 0.72);
+  background: rgba(122, 155, 122, 0.11);
+  box-shadow: 0 0 0 1px rgba(122, 155, 122, 0.32),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07), 0 2px 5px rgba(10, 8, 6, 0.18);
 }
 
-.layer-tile:hover {
-  background: var(--color-surface);
-}
-
-.layer-tile.is-on.is-visible:hover {
-  background: rgba(122, 155, 122, 0.12);
-}
-
+.layer-tile.is-on.is-visible:hover,
 .layer-tile.is-on.layer-tile--primary:hover {
-  background: rgba(193, 127, 74, 0.22);
+  background: rgba(122, 155, 122, 0.14);
+  border-color: rgba(122, 155, 122, 0.78);
+  box-shadow: 0 0 0 1px rgba(122, 155, 122, 0.38),
+    inset 0 1px 0 rgba(255, 255, 255, 0.09), 0 2px 7px rgba(10, 8, 6, 0.2);
+}
+
+.layer-tile.is-on.is-visible:active:not(:focus-visible),
+.layer-tile.is-on.layer-tile--primary:active:not(:focus-visible) {
+  box-shadow: inset 0 2px 8px rgba(10, 8, 6, 0.22),
+    0 0 0 1px rgba(122, 155, 122, 0.28);
 }
 
 .layer-tile:focus-visible {
@@ -1369,33 +1455,42 @@ body.otef-remote-shell {
   box-shadow: var(--focus-ring-primary);
 }
 
-.layer-tile.is-on.layer-tile--primary:focus-visible {
-  box-shadow: var(--focus-ring-primary), 0 0 0 1px rgba(193, 127, 74, 0.45);
+.layer-tile.is-off:focus-visible {
+  box-shadow: var(--focus-ring-primary), var(--shadow-pressed-terracotta),
+    var(--shadow-pressed-inset), 0 1px 0 rgba(245, 240, 234, 0.07);
 }
 
-.layer-tile__preview {
-  inline-size: 32px;
-  block-size: 32px;
-  border-radius: 6px;
-  border: 2px solid;
-  flex-shrink: 0;
-  margin-block-end: var(--space-xs);
+.layer-tile.is-on:focus-visible {
+  box-shadow: var(--focus-ring-primary), inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 1px 3px rgba(10, 8, 6, 0.22);
+}
+
+.layer-tile.is-on.is-visible:focus-visible,
+.layer-tile.is-on.layer-tile--primary:focus-visible {
+  box-shadow: var(--focus-ring-primary), 0 0 0 1px rgba(122, 155, 122, 0.32),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07), 0 2px 5px rgba(10, 8, 6, 0.18);
 }
 
 .layer-tile__label {
-  display: block;
+  flex: 1 1 auto;
+  min-height: 0;
   width: 100%;
-  font: var(--font-label-sm);
+  max-width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font: var(--font-body-md);
   line-height: 1.3;
   color: inherit;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: clip;
-  flex: 1 1 auto;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  hyphens: auto;
+  text-align: center;
   padding-inline: 2px;
+  min-width: 0;
 }
 
-/* Tile-level animation: icon control only (not “Flow” text) */
+/* Tile-level animation: full-width bar (short height; wide hit area) on .layer-tile--anim only */
 .anim-btn {
   position: absolute;
   inset-block-end: 6px;
@@ -1418,6 +1513,21 @@ body.otef-remote-shell {
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.layer-tile--anim .anim-btn {
+  inset-inline-start: 6px;
+  inset-inline-end: 6px;
+  width: auto;
+  height: 40px;
+  min-width: 0;
+  min-height: 40px;
+  border-radius: 8px;
+}
+
+.layer-tile--anim .anim-btn__glyph {
+  width: 16px;
+  height: 16px;
 }
 
 .anim-btn__glyph {
@@ -1445,53 +1555,16 @@ body.otef-remote-shell {
   box-shadow: var(--focus-ring-primary);
 }
 
-/* Inert slot: same footprint as .anim-btn for consistent tile geometry */
-.anim-btn--absent {
-  pointer-events: none;
-  opacity: 0;
-  cursor: default;
-  border: none;
-  background: transparent;
-}
-
 .layer-bulk-visibility {
   flex-shrink: 0;
 }
 
-/* Variant C: one screen — pack head + edge-faded strip + hint + bulk + grid */
+/* Variant C: one screen — edge-faded pack strip + bulk + grid */
 .layers-variant-c {
   display: flex;
   flex-direction: column;
   min-width: 0;
   padding-bottom: 2px;
-}
-
-.layers-pack-head {
-  display: flex;
-  flex-direction: row;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: var(--space-sm);
-  margin-block-end: 6px;
-  margin-inline: 2px;
-}
-
-.layers-pack-head__label {
-  margin: 0;
-  font: var(--font-label-sm);
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  color: var(--color-ink-muted);
-  font-size: 0.59rem;
-}
-
-.layers-pack-scroll-hint {
-  font-size: 0.62rem;
-  line-height: 1.35;
-  color: var(--color-ink-subtle);
-  margin: 0 2px 8px;
-  text-align: center;
-  letter-spacing: 0.02em;
 }
 
 .layers-pack-strip-wrap {
@@ -1508,15 +1581,23 @@ body.otef-remote-shell {
 }
 
 .layers-pack-strip__viewport {
+  /* ~2 rows of chips: padding + 2× chip row + row gap (see .pack-chip min-block-size) */
+  --pack-strip-chip-min: max(44px, 2.75rem);
+  --pack-strip-1row-h: calc(6px + 10px + var(--pack-strip-chip-min));
+  --pack-strip-viewport-h: calc(
+    6px + 10px + 2 * var(--pack-strip-chip-min) + var(--space-md)
+  );
   position: relative;
   margin-inline: -4px;
   padding-inline: 4px;
   overflow: hidden;
 }
 
+/* Edge fades: stretch to match viewport (1–2 rows or scroll area height) */
 .layers-pack-strip__edge {
   position: absolute;
-  inset-block: 0;
+  inset-block-start: 0;
+  inset-block-end: 0;
   width: 22px;
   z-index: 1;
   pointer-events: none;
@@ -1562,20 +1643,17 @@ body.otef-remote-shell {
   );
 }
 
+/* Two pack rows scroll together horizontally (see .layers-pack-strip__band in JS). */
 .layers-pack-strip__scroller {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  gap: var(--space-sm);
   min-width: 0;
+  min-height: 0;
   overflow-x: auto;
   overflow-y: hidden;
-  scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
   -ms-overflow-style: none;
-  padding-block: 4px 8px 10px;
-  padding-inline: 6px 12px;
+  padding-block: 6px 10px;
+  padding-inline: 8px 14px;
   box-sizing: border-box;
 }
 
@@ -1583,23 +1661,50 @@ body.otef-remote-shell {
   display: none;
 }
 
+.layers-pack-strip__band {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-xs);
+  width: max-content;
+}
+
+.layers-pack-strip__row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: var(--space-md);
+  width: max-content;
+}
+
 .pack-chip {
+  display: inline-flex;
   flex: 0 0 auto;
-  scroll-snap-align: start;
+  align-items: center;
+  gap: 8px;
   margin: 0;
-  padding: 8px 14px;
+  padding-block: 11px;
+  padding-inline: 18px;
+  min-block-size: 44px;
   border-radius: var(--rounded-pill);
   border: 1px solid var(--color-border-strong);
   background: var(--color-surface-raised);
   color: var(--color-ink-muted);
   font: var(--font-label-sm);
   font-weight: 600;
-  font-size: 0.78rem;
-  line-height: 1.25;
+  font-size: 0.875rem;
+  line-height: 1.2;
   white-space: nowrap;
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.pack-chip .group-count {
+  flex-shrink: 0;
+  font-size: 0.6875rem;
+  padding: 1px 6px;
 }
 
 .pack-chip:focus-visible {
@@ -1703,6 +1808,12 @@ body.otef-remote-shell {
   input[type="checkbox"]:checked
   + .toggle-indicator::after {
   transform: translateX(-20px);
+}
+
+/* Bulk pack visibility (focused toolbar only): green when on — not primary orange */
+.focused-pack-toolbar .layer-bulk-visibility input[type="checkbox"]:checked + .toggle-indicator {
+  background: var(--color-success);
+  border-color: var(--color-success);
 }
 
 /* Accessibility */

--- a/otef-interactive/frontend/curation.html
+++ b/otef-interactive/frontend/curation.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="he">
   <head>
     <meta charset="UTF-8" />
     <meta
@@ -8,8 +8,27 @@
     />
     <meta name="mobile-web-app-capable" content="yes" />
     <title>OTEF Curation</title>
+    <script>
+      (function () {
+        try {
+          if (typeof window === "undefined" || typeof document === "undefined") return;
+          var q = (typeof location !== "undefined" && location.search) || "";
+          var p = new URLSearchParams(q);
+          var embed = p.get("embed");
+          if (embed !== "1" && embed !== "true") return;
+          if (window.self !== window.top) {
+            document.documentElement.classList.add("curation-embed");
+          }
+        } catch (e) {
+          /* no-op */
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="css/remote-styles.css" />
     <style>
+      html.curation-embed .curation-header {
+        display: none !important;
+      }
       .curation-layout {
         display: flex;
         flex-direction: column;
@@ -297,6 +316,22 @@
         position: relative;
         width: 100%;
       }
+      .curation-submission-combo-row {
+        display: flex;
+        flex-direction: row;
+        align-items: stretch;
+        gap: var(--spacing-unit);
+        width: 100%;
+        box-sizing: border-box;
+      }
+      .curation-submission-combo-row .curation-submission-combo-field {
+        flex: 1;
+        min-width: 0;
+      }
+      .curation-submission-combo-row .curation-submissions-refresh {
+        align-self: center;
+        flex-shrink: 0;
+      }
       .curation-submission-combo-field {
         position: relative;
         border: 1px solid var(--border-color);
@@ -508,16 +543,64 @@
         background: rgba(255, 200, 0, 0.12);
         color: #ffe999;
       }
+      .curation-submissions-toolbar {
+        margin-bottom: 6px;
+      }
+      .curation-submissions-toolbar h2 {
+        margin-bottom: 0;
+      }
+      .curation-submissions-refresh {
+        flex-shrink: 0;
+        box-sizing: border-box;
+        min-width: 44px;
+        min-height: 44px;
+        width: 44px;
+        height: 44px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0;
+        border: 1px solid var(--border-color);
+        border-radius: var(--border-radius);
+        background: var(--bg-tertiary);
+        color: var(--text-primary);
+        cursor: pointer;
+      }
+      .curation-submissions-refresh:hover {
+        background: var(--bg-secondary);
+      }
+      .curation-submissions-refresh:focus-visible {
+        outline: 2px solid var(--accent, #00d4ff);
+        outline-offset: 2px;
+      }
+      .curation-submissions-refresh svg {
+        display: block;
+        width: 20px;
+        height: 20px;
+      }
     </style>
   </head>
   <body>
     <div class="curation-layout">
       <header class="curation-header">
         <div class="header-content">
-          <a href="remote-controller.html" id="curationBack" class="curation-header-btn back" aria-label="Open controller">Controller</a>
-          <h1 class="remote-title">Curation</h1>
-          <button type="button" id="curationRefresh" class="curation-header-btn">
-            Refresh
+          <a
+            href="remote-controller.html"
+            id="curationBack"
+            class="curation-header-btn back"
+            data-i18n="curationBackLink"
+            data-i18n-aria="curationBackAria"
+            >בקר</a
+          >
+          <h1 class="remote-title" data-i18n="curationPageTitle">אצירה</h1>
+          <button
+            type="button"
+            id="curationRefresh"
+            class="curation-header-btn"
+            data-i18n="curationHeaderRefresh"
+            data-i18n-aria="curationHeaderRefreshAria"
+          >
+            רענון
           </button>
         </div>
       </header>
@@ -525,49 +608,71 @@
       <div class="curation-body">
         <aside class="curation-sidebar">
           <section class="curation-section">
-            <h2>Submissions</h2>
+            <div class="curation-submissions-toolbar">
+              <h2 data-i18n="curationSubmissionsHeading">הגשות</h2>
+            </div>
             <div id="curationSubmissionCombo" class="curation-submission-combo">
               <input type="hidden" id="curationSubmission" name="curationSubmission" value="" />
-              <div id="curationSubmissionComboField" class="curation-submission-combo-field">
-                <input
-                  type="search"
-                  id="curationSubmissionSearch"
-                  class="curation-submission-search"
-                  placeholder="Search or choose submission…"
-                  autocomplete="off"
-                  dir="auto"
-                  role="combobox"
-                  aria-expanded="false"
-                  aria-controls="curationSubmissionList"
-                  aria-autocomplete="list"
-                  aria-label="Search and select submission"
-                />
-                <div
-                  id="curationSubmissionSelectedTags"
-                  class="curation-submission-selected-tags"
-                  aria-hidden="true"
-                ></div>
+              <div class="curation-submission-combo-row">
+                <div id="curationSubmissionComboField" class="curation-submission-combo-field">
+                  <input
+                    type="search"
+                    id="curationSubmissionSearch"
+                    class="curation-submission-search"
+                    placeholder="חיפוש או בחירת הגשה…"
+                    data-i18n-placeholder="curationSubmissionSearchPlaceholder"
+                    autocomplete="off"
+                    dir="auto"
+                    role="combobox"
+                    aria-expanded="false"
+                    aria-controls="curationSubmissionList"
+                    aria-autocomplete="list"
+                    data-i18n-aria="curationSubmissionSearchAria"
+                    aria-label="חיפוש ובחירת הגשה"
+                  />
+                  <div
+                    id="curationSubmissionSelectedTags"
+                    class="curation-submission-selected-tags"
+                    aria-hidden="true"
+                  ></div>
+                </div>
+                <button
+                  type="button"
+                  id="curationSubmissionsRefresh"
+                  class="curation-submissions-refresh"
+                  data-i18n-title="curationSubmissionsRefreshTitle"
+                  data-i18n-aria="curationSubmissionsRefreshAria"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+                    <path d="M21 3v5h-5" />
+                    <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+                    <path d="M3 21v-5h5" />
+                  </svg>
+                </button>
               </div>
               <div
                 id="curationSubmissionList"
                 class="curation-submission-list"
                 role="listbox"
-                aria-label="Submissions"
+                data-i18n-aria="curationSubmissionListAria"
+                aria-label="הגשות"
                 hidden
               ></div>
             </div>
           </section>
 
           <section class="curation-section">
-            <h2>Publish</h2>
+            <h2 data-i18n="curationPublishHeading">פרסום</h2>
             <div class="curation-publish-actions">
               <button
                 type="button"
                 id="curationPublish"
                 class="curation-publish-btn"
+                data-i18n="curationPublishButton"
                 disabled
               >
-                Publish as OTEF layer
+                פרסום כשכבת OTEF
               </button>
             </div>
             <div id="curationStatus" class="curation-status"></div>
@@ -575,23 +680,29 @@
 
           <section class="curation-section">
             <div class="curation-section-head">
-              <h2>Published layers on remote</h2>
+              <h2 data-i18n="curationPublishedHeading">שכבות מפורסמות בבקר</h2>
               <div class="curation-section-head-actions">
                 <label class="curation-workshop-label">
                   <input
                     type="checkbox"
                     id="curationWorkshopAutoPublish"
-                    aria-label="Workshop auto-publish"
+                    data-i18n-aria="curationWorkshopAutoPublishAria"
+                    aria-label="פרסום אוטומטי לסדנה"
                   />
-                  Workshop auto-publish
+                  <span data-i18n="curationWorkshopAutoPublish">פרסום אוטומטי לסדנה</span>
                 </label>
-                <button type="button" id="curationUnpublishAll" class="curation-header-btn">
-                  Unpublish all
+                <button
+                  type="button"
+                  id="curationUnpublishAll"
+                  class="curation-header-btn"
+                  data-i18n="curationUnpublishAll"
+                >
+                  בטל את כל הפרסומים
                 </button>
               </div>
             </div>
             <div id="curationPublishedLayers" class="curation-published-layers curation-features">
-              <div class="curation-status">Loading published curated layers…</div>
+              <div class="curation-status" data-i18n="curationPublishedLoading">טוען שכבות אצירה מפורסמות…</div>
             </div>
           </section>
         </aside>

--- a/otef-interactive/frontend/curation.html
+++ b/otef-interactive/frontend/curation.html
@@ -99,11 +99,11 @@
         margin: 0;
         cursor: pointer;
       }
-      .curation-section-head h2 {
+      .curation-section-head .curation-published-heading {
         margin-bottom: 0;
       }
       .curation-publish-actions {
-        margin-top: 8px;
+        margin-top: 0;
       }
       .curation-section {
         margin-bottom: var(--spacing-unit);
@@ -111,7 +111,7 @@
       .curation-section:last-child {
         margin-bottom: 0;
       }
-      .curation-section h2 {
+      .curation-section .curation-published-heading {
         font-size: 11px;
         font-weight: 600;
         color: var(--text-secondary);
@@ -543,12 +543,6 @@
         background: rgba(255, 200, 0, 0.12);
         color: #ffe999;
       }
-      .curation-submissions-toolbar {
-        margin-bottom: 6px;
-      }
-      .curation-submissions-toolbar h2 {
-        margin-bottom: 0;
-      }
       .curation-submissions-refresh {
         flex-shrink: 0;
         box-sizing: border-box;
@@ -608,9 +602,6 @@
       <div class="curation-body">
         <aside class="curation-sidebar">
           <section class="curation-section">
-            <div class="curation-submissions-toolbar">
-              <h2 data-i18n="curationSubmissionsHeading">הגשות</h2>
-            </div>
             <div id="curationSubmissionCombo" class="curation-submission-combo">
               <input type="hidden" id="curationSubmission" name="curationSubmission" value="" />
               <div class="curation-submission-combo-row">
@@ -622,7 +613,6 @@
                     placeholder="חיפוש או בחירת הגשה…"
                     data-i18n-placeholder="curationSubmissionSearchPlaceholder"
                     autocomplete="off"
-                    dir="auto"
                     role="combobox"
                     aria-expanded="false"
                     aria-controls="curationSubmissionList"
@@ -663,7 +653,6 @@
           </section>
 
           <section class="curation-section">
-            <h2 data-i18n="curationPublishHeading">פרסום</h2>
             <div class="curation-publish-actions">
               <button
                 type="button"
@@ -672,7 +661,7 @@
                 data-i18n="curationPublishButton"
                 disabled
               >
-                פרסום כשכבת OTEF
+               פרסם שכבה
               </button>
             </div>
             <div id="curationStatus" class="curation-status"></div>
@@ -680,7 +669,14 @@
 
           <section class="curation-section">
             <div class="curation-section-head">
-              <h2 data-i18n="curationPublishedHeading">שכבות מפורסמות בבקר</h2>
+              <div
+                class="curation-published-heading"
+                role="heading"
+                aria-level="2"
+                data-i18n="curationPublishedHeading"
+              >
+                שכבות מפורסמות בבקר
+              </div>
               <div class="curation-section-head-actions">
                 <label class="curation-workshop-label">
                   <input
@@ -697,7 +693,7 @@
                   class="curation-header-btn"
                   data-i18n="curationUnpublishAll"
                 >
-                  בטל את כל הפרסומים
+                 הסר הכל
                 </button>
               </div>
             </div>

--- a/otef-interactive/frontend/remote-controller.html
+++ b/otef-interactive/frontend/remote-controller.html
@@ -31,7 +31,7 @@
             data-locale="he"
             aria-pressed="true"
           >
-            עברית
+            עב
           </button>
           <button
             type="button"
@@ -40,7 +40,7 @@
             data-locale="en"
             aria-pressed="false"
           >
-            English
+            en
           </button>
         </div>
         <div class="header-end">
@@ -74,113 +74,125 @@
           aria-labelledby="remote-tab-navigation"
         >
           <section class="control-section" id="navigationSection">
-            <div class="dpad-container">
-              <div class="dpad">
-                <button
-                  class="dpad-button dpad-up"
-                  id="panNorth"
-                  data-i18n-aria="ariaPanNorth"
-                  aria-label="הזזה צפונה"
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <polyline points="18 15 12 9 6 15"></polyline>
-                  </svg>
-                </button>
-                <button
-                  class="dpad-button dpad-left"
-                  id="panWest"
-                  data-i18n-aria="ariaPanWest"
-                  aria-label="הזזה מערבה"
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <polyline points="15 18 9 12 15 6"></polyline>
-                  </svg>
-                </button>
-                <button
-                  class="dpad-button dpad-right"
-                  id="panEast"
-                  data-i18n-aria="ariaPanEast"
-                  aria-label="הזזה מזרחה"
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <polyline points="9 18 15 12 9 6"></polyline>
-                  </svg>
-                </button>
-                <button
-                  class="dpad-button dpad-down"
-                  id="panSouth"
-                  data-i18n-aria="ariaPanSouth"
-                  aria-label="הזזה דרומה"
-                >
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                  >
-                    <polyline points="6 9 12 15 18 9"></polyline>
-                  </svg>
-                </button>
-                <div
-                  class="joystick-container"
-                  id="joystickZone"
-                  data-i18n-aria="joystickAria"
-                  aria-label="מוט כיוון לגרירת המפה"
-                >
-                  <div class="joystick-base"></div>
+            <div class="navigation-panel-stack">
+              <div class="navigation-group navigation-group--pan">
+                <div class="navigation-group-label" data-i18n="navPanGroupLabel">
+                  הזזה
+                </div>
+                <div class="dpad-container">
+                  <div class="dpad">
+                    <button
+                      class="dpad-button dpad-up"
+                      id="panNorth"
+                      data-i18n-aria="ariaPanNorth"
+                      aria-label="הזזה צפונה"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <polyline points="18 15 12 9 6 15"></polyline>
+                      </svg>
+                    </button>
+                    <button
+                      class="dpad-button dpad-left"
+                      id="panWest"
+                      data-i18n-aria="ariaPanWest"
+                      aria-label="הזזה מערבה"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <polyline points="15 18 9 12 15 6"></polyline>
+                      </svg>
+                    </button>
+                    <button
+                      class="dpad-button dpad-right"
+                      id="panEast"
+                      data-i18n-aria="ariaPanEast"
+                      aria-label="הזזה מזרחה"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <polyline points="9 18 15 12 9 6"></polyline>
+                      </svg>
+                    </button>
+                    <button
+                      class="dpad-button dpad-down"
+                      id="panSouth"
+                      data-i18n-aria="ariaPanSouth"
+                      aria-label="הזזה דרומה"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                      >
+                        <polyline points="6 9 12 15 18 9"></polyline>
+                      </svg>
+                    </button>
+                    <div
+                      class="joystick-container"
+                      id="joystickZone"
+                      data-i18n-aria="joystickAria"
+                      aria-label="מוט כיוון לגרירת המפה"
+                    >
+                      <div class="joystick-base"></div>
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <div class="zoom-controls">
-              <div class="zoom-display">
-                <span class="zoom-label" data-i18n="zoomLabel">זום:</span>
-                <span class="zoom-value" id="zoomValue">--</span>
-              </div>
-              <div class="zoom-slider-container">
-                <input
-                  type="range"
-                  id="zoomSlider"
-                  class="zoom-slider"
-                  min="10"
-                  max="19"
-                  value="15"
-                  step="1"
-                  data-i18n-aria="ariaZoomLevel"
-                  aria-label="רמת מיקוד"
-                />
-                <div class="zoom-buttons">
-                  <button
-                    class="zoom-button zoom-out"
-                    id="zoomOut"
-                    data-i18n-aria="ariaZoomOut"
-                    aria-label="התרחקות"
-                  >
-                    −
-                  </button>
-                  <button
-                    class="zoom-button zoom-in"
-                    id="zoomIn"
-                    data-i18n-aria="ariaZoomIn"
-                    aria-label="התקרבות"
-                  >
-                    +
-                  </button>
+              <div class="navigation-group navigation-group--zoom">
+                <div class="navigation-group-label" data-i18n="navZoomGroupLabel">
+                  זום
+                </div>
+                <div class="zoom-controls">
+                  <div class="zoom-display">
+                    <span class="zoom-label" data-i18n="zoomLabel">זום:</span>
+                    <span class="zoom-value" id="zoomValue">--</span>
+                  </div>
+                  <div class="zoom-slider-container">
+                    <input
+                      type="range"
+                      id="zoomSlider"
+                      class="zoom-slider"
+                      min="10"
+                      max="19"
+                      value="15"
+                      step="1"
+                      data-i18n-aria="ariaZoomLevel"
+                      aria-label="רמת מיקוד"
+                    />
+                    <div class="zoom-buttons">
+                      <button
+                        class="zoom-button zoom-out"
+                        id="zoomOut"
+                        data-i18n-aria="ariaZoomOut"
+                        aria-label="התרחקות"
+                      >
+                        −
+                      </button>
+                      <button
+                        class="zoom-button zoom-in"
+                        id="zoomIn"
+                        data-i18n-aria="ariaZoomIn"
+                        aria-label="התקרבות"
+                      >
+                        +
+                      </button>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/otef-interactive/frontend/remote-controller.html
+++ b/otef-interactive/frontend/remote-controller.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="he">
   <head>
     <meta charset="UTF-8" />
     <meta
@@ -11,159 +11,353 @@
       name="apple-mobile-web-app-status-bar-style"
       content="black-translucent"
     />
-    <title>OTEF Remote Controller</title>
+    <title>OTEF</title>
     <link rel="stylesheet" href="css/remote-styles.css" />
   </head>
-  <body>
-    <!-- Header with connection status -->
+  <body class="otef-remote-shell">
     <header class="remote-header">
-      <div class="header-content">
-        <h1 class="remote-title">Remote</h1>
-        <a href="curation.html" class="curation-link" aria-label="Open Curation">Curation</a>
-        <div class="connection-status" id="connectionStatus">
-          <span class="status-indicator" id="statusIndicator"></span>
-          <span class="status-text" id="statusText">Connecting...</span>
+      <div class="header-top">
+        <div
+          class="remote-locale-toggle"
+          role="group"
+          data-i18n-aria="localeGroupAria"
+          aria-label="בחירת שפה"
+          id="remoteLocaleToggle"
+        >
+          <button
+            type="button"
+            class="remote-locale-btn is-active"
+            id="remoteLocaleHe"
+            data-locale="he"
+            aria-pressed="true"
+          >
+            עברית
+          </button>
+          <button
+            type="button"
+            class="remote-locale-btn"
+            id="remoteLocaleEn"
+            data-locale="en"
+            aria-pressed="false"
+          >
+            English
+          </button>
+        </div>
+        <div class="header-end">
+          <div
+            class="connection-status"
+            id="connectionStatus"
+            dir="ltr"
+          >
+            <span class="status-indicator" id="statusIndicator"></span>
+            <span class="status-text" id="statusText">מתחבר…</span>
+          </div>
         </div>
       </div>
-      <!-- Table Switcher -->
-      <div id="table-switcher" style="padding: 0 16px 8px 16px"></div>
+      <!--
+        Table switcher mount: #table-switcher stays in the DOM (table-switcher.js,
+        redirect/query, curation embed). Deliberately hidden in CSS for this controller
+        shell (Task 4) — not a broken layout; show later by overriding #table-switcher
+        display without removing or renaming the node.
+      -->
+      <div id="table-switcher" aria-hidden="true"></div>
     </header>
 
-    <!-- Main content area -->
-    <main class="remote-main">
-      <!-- Navigation Controls Section -->
-      <section class="control-section" id="navigationSection">
-        <h2 class="section-title">Navigation</h2>
+    <main class="remote-main" id="remoteMain" dir="rtl">
+      <div class="remote-tab-panels" id="remoteTabPanels">
+        <!-- Tab: Navigation — map controls (ids preserved for remote-controller.js) -->
+        <section
+          class="remote-tab-panel"
+          data-remote-tab="navigation"
+          id="remote-panel-navigation"
+          role="tabpanel"
+          aria-labelledby="remote-tab-navigation"
+        >
+          <section class="control-section" id="navigationSection">
+            <div class="dpad-container">
+              <div class="dpad">
+                <button
+                  class="dpad-button dpad-up"
+                  id="panNorth"
+                  data-i18n-aria="ariaPanNorth"
+                  aria-label="הזזה צפונה"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <polyline points="18 15 12 9 6 15"></polyline>
+                  </svg>
+                </button>
+                <button
+                  class="dpad-button dpad-left"
+                  id="panWest"
+                  data-i18n-aria="ariaPanWest"
+                  aria-label="הזזה מערבה"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <polyline points="15 18 9 12 15 6"></polyline>
+                  </svg>
+                </button>
+                <button
+                  class="dpad-button dpad-right"
+                  id="panEast"
+                  data-i18n-aria="ariaPanEast"
+                  aria-label="הזזה מזרחה"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <polyline points="9 18 15 12 9 6"></polyline>
+                  </svg>
+                </button>
+                <button
+                  class="dpad-button dpad-down"
+                  id="panSouth"
+                  data-i18n-aria="ariaPanSouth"
+                  aria-label="הזזה דרומה"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <polyline points="6 9 12 15 18 9"></polyline>
+                  </svg>
+                </button>
+                <div
+                  class="joystick-container"
+                  id="joystickZone"
+                  data-i18n-aria="joystickAria"
+                  aria-label="מוט כיוון לגרירת המפה"
+                >
+                  <div class="joystick-base"></div>
+                </div>
+              </div>
+            </div>
 
-        <!-- Directional pad -->
-        <div class="dpad-container">
-          <div class="dpad">
-            <button
-              class="dpad-button dpad-up"
-              id="panNorth"
-              aria-label="Pan North"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <polyline points="18 15 12 9 6 15"></polyline>
-              </svg>
-            </button>
-            <button
-              class="dpad-button dpad-left"
-              id="panWest"
-              aria-label="Pan West"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <polyline points="15 18 9 12 15 6"></polyline>
-              </svg>
-            </button>
-            <button
-              class="dpad-button dpad-right"
-              id="panEast"
-              aria-label="Pan East"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <polyline points="9 18 15 12 9 6"></polyline>
-              </svg>
-            </button>
-            <button
-              class="dpad-button dpad-down"
-              id="panSouth"
-              aria-label="Pan South"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-              >
-                <polyline points="6 9 12 15 18 9"></polyline>
-              </svg>
-            </button>
-            <!-- Joystick in center -->
-            <div
-              class="joystick-container"
-              id="joystickZone"
-              aria-label="Virtual joystick for map panning"
-            >
-              <div class="joystick-base"></div>
+            <div class="zoom-controls">
+              <div class="zoom-display">
+                <span class="zoom-label" data-i18n="zoomLabel">זום:</span>
+                <span class="zoom-value" id="zoomValue">--</span>
+              </div>
+              <div class="zoom-slider-container">
+                <input
+                  type="range"
+                  id="zoomSlider"
+                  class="zoom-slider"
+                  min="10"
+                  max="19"
+                  value="15"
+                  step="1"
+                  data-i18n-aria="ariaZoomLevel"
+                  aria-label="רמת מיקוד"
+                />
+                <div class="zoom-buttons">
+                  <button
+                    class="zoom-button zoom-out"
+                    id="zoomOut"
+                    data-i18n-aria="ariaZoomOut"
+                    aria-label="התרחקות"
+                  >
+                    −
+                  </button>
+                  <button
+                    class="zoom-button zoom-in"
+                    id="zoomIn"
+                    data-i18n-aria="ariaZoomIn"
+                    aria-label="התקרבות"
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section
+            class="control-section"
+            id="layersSection"
+            hidden
+            aria-hidden="true"
+          >
+            <h2 class="section-title">Layers</h2>
+            <div class="layer-controls">
+              <!-- Legacy layer toggles — compatibility -->
+            </div>
+          </section>
+        </section>
+
+        <!-- Tab: Layers — layer sheet host; Task 6 will align panel + sheet UX -->
+        <section
+          class="remote-tab-panel"
+          data-remote-tab="layers"
+          id="remote-panel-layers"
+          role="tabpanel"
+          aria-labelledby="remote-tab-layers"
+          hidden
+        >
+          <div class="remote-layer-host" id="remoteLayerHost">
+            <!-- #layerSheet — panel root; LayerSheetController (Task 6) -->
+            <div class="layer-panel" id="layerSheet">
+              <div class="layer-panel-header">
+                <button
+                  type="button"
+                  class="layer-panel-back"
+                  id="layerPanelBack"
+                  hidden
+                  data-i18n-aria="ariaLayersBack"
+                >
+                  <svg
+                    class="layer-panel-back__icon"
+                    viewBox="0 0 24 24"
+                    width="20"
+                    height="20"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M15 18l-6-6 6-6" />
+                  </svg>
+                </button>
+                <div class="layer-panel-header__text">
+                  <span
+                    class="sheet-title"
+                    data-i18n="layerSheetTitle"
+                    id="layerPanelTitle"
+                    >שכבות</span>
+                  <span
+                    class="layer-count"
+                    data-i18n="layersActiveCount"
+                    data-i18n-n="0"
+                    id="layerPanelCount"
+                    >0 פעיל</span>
+                </div>
+              </div>
+              <div class="sheet-content" id="layerPanelContent">
+                <!-- Populated by LayerSheetController -->
+              </div>
             </div>
           </div>
-        </div>
+        </section>
 
-        <!-- Zoom controls -->
-        <div class="zoom-controls">
-          <div class="zoom-display">
-            <span class="zoom-label">Zoom:</span>
-            <span class="zoom-value" id="zoomValue">--</span>
+        <!--
+          Tab: Workshop (display) — data-remote-tab=curation for embed + routing contract
+          (Task 7: curation.html iframe, ?embed=1)
+        -->
+        <section
+          class="remote-tab-panel"
+          data-remote-tab="curation"
+          id="remote-panel-curation"
+          role="tabpanel"
+          aria-labelledby="remote-tab-curation"
+          hidden
+        >
+          <div
+            class="remote-curation-surface"
+            id="remoteCurationSurface"
+            data-embed-surface="curation"
+          >
+            <!--
+              Embed contract: parent remote-controller owns startCuratedSupabaseHeartbeat only.
+              Iframe src MUST include ?embed=1 so curation bootstrap skips duplicate heartbeat init
+              (see frontend/src/curation/curation-embed.js).
+            -->
+            <iframe
+              id="remoteCurationFrame"
+              class="remote-curation-frame"
+              title="סדנה"
+              data-i18n-title="curationIframeTitle"
+              src="curation.html?embed=1"
+              loading="lazy"
+            ></iframe>
           </div>
-          <div class="zoom-slider-container">
-            <input
-              type="range"
-              id="zoomSlider"
-              class="zoom-slider"
-              min="10"
-              max="19"
-              value="15"
-              step="1"
-              aria-label="Zoom level"
-            />
-            <div class="zoom-buttons">
-              <button
-                class="zoom-button zoom-out"
-                id="zoomOut"
-                aria-label="Zoom Out"
-              >
-                −
-              </button>
-              <button
-                class="zoom-button zoom-in"
-                id="zoomIn"
-                aria-label="Zoom In"
-              >
-                +
-              </button>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <!-- Layer Controls Section - Legacy (kept for backward compatibility) -->
-      <section class="control-section" id="layersSection" style="display: none">
-        <h2 class="section-title">Layers</h2>
-        <div class="layer-controls">
-          <!-- Legacy layer toggles hidden but kept for compatibility -->
-        </div>
-      </section>
+        </section>
+      </div>
     </main>
 
-    <!-- Layer Bottom Sheet -->
-    <div class="layer-sheet" id="layerSheet">
-      <div class="sheet-handle"></div>
-      <div class="sheet-header">
-        <span class="sheet-title">Layers</span>
-        <span class="layer-count">0 active</span>
-      </div>
-      <div class="sheet-content">
-        <!-- Dynamically populated groups -->
-      </div>
-    </div>
+    <nav
+      class="remote-bottom-nav"
+      id="remoteBottomNav"
+      role="tablist"
+      data-i18n-aria="navTablistAria"
+      aria-label="אזורי בקרה"
+    >
+      <!-- LTR visual: left → Workshop, middle → Layers, right → Nav -->
+      <button
+        type="button"
+        class="remote-bottom-nav__tab"
+        id="remote-tab-curation"
+        role="tab"
+        aria-selected="false"
+        aria-controls="remote-panel-curation"
+        tabindex="-1"
+        data-remote-tab="curation"
+      >
+        <span class="remote-bottom-nav__icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <path d="M3 9h18M9 21V9" />
+          </svg>
+        </span>
+        <span
+          class="remote-bottom-nav__label"
+          data-curation-surface="workshop"
+          data-i18n="navCuration"
+        >סדנה</span>
+      </button>
+      <button
+        type="button"
+        class="remote-bottom-nav__tab"
+        id="remote-tab-layers"
+        role="tab"
+        aria-selected="false"
+        aria-controls="remote-panel-layers"
+        tabindex="-1"
+        data-remote-tab="layers"
+      >
+        <span class="remote-bottom-nav__icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2L2 7l10 5 10-5-10-5z" />
+            <path d="M2 17l10 5 10-5" />
+            <path d="M2 12l10 5 10-5" />
+          </svg>
+        </span>
+        <span class="remote-bottom-nav__label" data-i18n="navLayers">שכבות</span>
+      </button>
+      <button
+        type="button"
+        class="remote-bottom-nav__tab is-active"
+        id="remote-tab-navigation"
+        role="tab"
+        aria-selected="true"
+        aria-controls="remote-panel-navigation"
+        tabindex="0"
+        data-remote-tab="navigation"
+      >
+        <span class="remote-bottom-nav__icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polygon points="3 11 22 2 13 22 11 13 3 11" />
+          </svg>
+        </span>
+        <span class="remote-bottom-nav__label" data-i18n="navNavigation">ניווט</span>
+      </button>
+    </nav>
 
-    <!-- Warning overlay (shown when GIS map not connected) -->
     <div class="warning-overlay hidden" id="warningOverlay">
       <div class="warning-content">
         <svg
@@ -179,14 +373,13 @@
           <line x1="12" y1="9" x2="12" y2="13"></line>
           <line x1="12" y1="17" x2="12.01" y2="17"></line>
         </svg>
-        <p class="warning-text">GIS map not connected. Controls disabled.</p>
+        <p class="warning-text" data-i18n="warningControlsDisabled">
+          המפה אינה מחוברת. הבקרות אינן פעילות.
+        </p>
       </div>
     </div>
 
-    <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/nipplejs@0.10.2/dist/nipplejs.min.js"></script>
     <script type="module" src="./src/entries/remote-main.js"></script>
   </body>
 </html>
-
-

--- a/otef-interactive/frontend/remote-controller.html
+++ b/otef-interactive/frontend/remote-controller.html
@@ -31,7 +31,7 @@
             data-locale="he"
             aria-pressed="true"
           >
-            עב
+            עברית
           </button>
           <button
             type="button"
@@ -40,7 +40,7 @@
             data-locale="en"
             aria-pressed="false"
           >
-            en
+            English
           </button>
         </div>
         <div class="header-end">
@@ -76,9 +76,10 @@
           <section class="control-section" id="navigationSection">
             <div class="navigation-panel-stack">
               <div class="navigation-group navigation-group--pan">
-                <div class="navigation-group-label" data-i18n="navPanGroupLabel">
-                  הזזה
-                </div>
+                <div
+                  class="navigation-group-label"
+                  data-i18n="navPanGroupLabel"
+                ></div>
                 <div class="dpad-container">
                   <div class="dpad">
                     <button
@@ -154,9 +155,6 @@
               </div>
 
               <div class="navigation-group navigation-group--zoom">
-                <div class="navigation-group-label" data-i18n="navZoomGroupLabel">
-                  זום
-                </div>
                 <div class="zoom-controls">
                   <div class="zoom-display">
                     <span class="zoom-label" data-i18n="zoomLabel">זום:</span>
@@ -223,43 +221,6 @@
           <div class="remote-layer-host" id="remoteLayerHost">
             <!-- #layerSheet — panel root; LayerSheetController (Task 6) -->
             <div class="layer-panel" id="layerSheet">
-              <div class="layer-panel-header">
-                <button
-                  type="button"
-                  class="layer-panel-back"
-                  id="layerPanelBack"
-                  hidden
-                  data-i18n-aria="ariaLayersBack"
-                >
-                  <svg
-                    class="layer-panel-back__icon"
-                    viewBox="0 0 24 24"
-                    width="20"
-                    height="20"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    aria-hidden="true"
-                  >
-                    <path d="M15 18l-6-6 6-6" />
-                  </svg>
-                </button>
-                <div class="layer-panel-header__text">
-                  <span
-                    class="sheet-title"
-                    data-i18n="layerSheetTitle"
-                    id="layerPanelTitle"
-                    >שכבות</span>
-                  <span
-                    class="layer-count"
-                    data-i18n="layersActiveCount"
-                    data-i18n-n="0"
-                    id="layerPanelCount"
-                    >0 פעיל</span>
-                </div>
-              </div>
               <div class="sheet-content" id="layerPanelContent">
                 <!-- Populated by LayerSheetController -->
               </div>

--- a/otef-interactive/frontend/src/curation/curation-embed.js
+++ b/otef-interactive/frontend/src/curation/curation-embed.js
@@ -1,0 +1,39 @@
+/**
+ * `curation.html` when loaded inside remote-controller must use `?embed=1` (or `embed=true`).
+ * Parent owns `startCuratedSupabaseHeartbeat`; this document must not start a second subscription.
+ * Heartbeat is skipped only when the embed flag is set **and** this document is in a
+ * subframe (true iframe); a top-level page with `?embed=1` must still run its own poll.
+ */
+
+/**
+ * @param {string} [locationSearch] — e.g. `window.location.search` or `?embed=1`
+ */
+export function getCurationEmbedModeFromSearch(locationSearch) {
+  const raw = String(locationSearch ?? "");
+  const q = raw.startsWith("?") ? raw.slice(1) : raw;
+  try {
+    const v = new URLSearchParams(q).get("embed");
+    return v === "1" || v === "true";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * @returns {boolean} True when this window is not the top-level browsing context (e.g. iframe).
+ */
+export function isOtefCurationInIframeContext() {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.self !== window.top;
+  } catch {
+    return false;
+  }
+}
+
+/** @returns {boolean} */
+export function isOtefCurationEmbedded() {
+  if (typeof window === "undefined") return false;
+  if (!getCurationEmbedModeFromSearch(window.location.search)) return false;
+  return isOtefCurationInIframeContext();
+}

--- a/otef-interactive/frontend/src/curation/curation-published-layers.js
+++ b/otef-interactive/frontend/src/curation/curation-published-layers.js
@@ -10,6 +10,29 @@ import {
   getSubmissionTagLabels,
 } from "./curation-submissions.js";
 
+/**
+ * When a row resolves to a known submission, use the same type_label → tags path as the combobox.
+ * Otherwise keep GeoJSON-derived tags.
+ * @param {string} resolvedSubmissionId normalized id or ""
+ * @param {string[] | null | undefined} geoInfoTags
+ * @param {(id: string) => string | null | undefined} [getSubmissionTypeLabel]
+ * @returns {string[]}
+ */
+export function resolvePublishedLayerInfoTags(
+  resolvedSubmissionId,
+  geoInfoTags,
+  getSubmissionTypeLabel,
+) {
+  const sid = String(resolvedSubmissionId || "").trim().toLowerCase();
+  const fallback = Array.isArray(geoInfoTags) ? geoInfoTags : [];
+  if (!sid) return fallback.slice();
+  const typeLabel = getSubmissionTypeLabel?.(sid);
+  if (typeLabel != null && String(typeLabel).trim() !== "") {
+    return getSubmissionTagLabels({ typeLabel: String(typeLabel).trim() });
+  }
+  return fallback.slice();
+}
+
 function displayCurationTagForPublishedList(tag) {
   const s = String(tag);
   if (s === "Tkuma Line") return t("curationTagTkumaLine");
@@ -193,6 +216,7 @@ export function derivePublishedLayerUiFields(activeLayer) {
  * @param {(submissionId: string) => boolean} deps.submissionExists
  * @param {(submissionId: string) => string} [deps.getSubmissionDisplayName]
  * @param {(submissionId: string) => string | null} [deps.getSubmissionColorCss]
+ * @param {(submissionId: string) => string | null} [deps.getSubmissionTypeLabel] submissions API type_label, same as combobox
  * @param {(displayName: string) => string | null} [deps.resolveSubmissionIdByDisplayName] when GeoJSON lacks submission_id, match card title to submission row name
  */
 export function createPublishedCuratedLayersPanel(deps) {
@@ -207,6 +231,7 @@ export function createPublishedCuratedLayersPanel(deps) {
     submissionExists,
     getSubmissionDisplayName = () => "",
     getSubmissionColorCss = () => null,
+    getSubmissionTypeLabel = () => null,
     resolveSubmissionIdByDisplayName,
   } = deps;
 
@@ -253,7 +278,12 @@ export function createPublishedCuratedLayersPanel(deps) {
           swatchInner !== ""
             ? `<span class="curation-published-layer-color" title="${escapeHtml(t("curationSubmissionColorTitle"))}">${swatchInner}</span>`
             : "";
-        const chips = renderTagChips(layer.infoTags);
+        const infoTags = resolvePublishedLayerInfoTags(
+          submissionId,
+          layer.infoTags,
+          getSubmissionTypeLabel,
+        );
+        const chips = renderTagChips(infoTags);
         const subName = submissionId ? String(getSubmissionDisplayName(submissionId) || "").trim() : "";
         const openLabel = submissionId
           ? subName

--- a/otef-interactive/frontend/src/curation/curation-published-layers.js
+++ b/otef-interactive/frontend/src/curation/curation-published-layers.js
@@ -2,7 +2,7 @@
  * Published curated layers list: load, render, unpublish, submission click-through.
  */
 
-import { t } from "../remote/remote-locale.js";
+import { getLocale, t } from "../remote/remote-locale.js";
 import { sanitizeCssColor } from "./curation-color-utils.js";
 import {
   buildCurationColorSwatchHtml,
@@ -156,11 +156,10 @@ export function formatUpdatedAtForUi(iso) {
   if (iso == null || String(iso).trim() === "") return "—";
   const d = new Date(String(iso));
   if (Number.isNaN(d.getTime())) return "—";
+  const locale = getLocale() === "he" ? "he-IL" : "en-US";
+  const opts = { dateStyle: "medium", timeStyle: "short", hour12: false };
   try {
-    return d.toLocaleString(undefined, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    });
+    return d.toLocaleString(locale, opts);
   } catch {
     return d.toISOString().slice(0, 16).replace("T", " ");
   }
@@ -168,13 +167,15 @@ export function formatUpdatedAtForUi(iso) {
 
 /**
  * @param {Record<string, unknown> | null | undefined} activeLayer
+ * @returns {{ updatedAtRaw: string; colorRaw: string | null; infoTags: string[] }}
  */
 export function derivePublishedLayerUiFields(activeLayer) {
   const data = getGeojsonDataFromGisLayerRecord(activeLayer);
   const updatedRaw =
     activeLayer && (activeLayer.updated_at ?? activeLayer.updatedAt ?? activeLayer.modified_at);
+  const updatedAtRaw = updatedRaw != null ? String(updatedRaw) : "";
   return {
-    updatedAtLabel: formatUpdatedAtForUi(updatedRaw != null ? String(updatedRaw) : ""),
+    updatedAtRaw,
     colorRaw: extractColorFromGeojsonData(data),
     infoTags: extractInfoTagsFromGeojsonData(data),
   };
@@ -186,7 +187,7 @@ export function derivePublishedLayerUiFields(activeLayer) {
  * @param {() => HTMLElement | null} deps.publishedLayersContainer
  * @param {(s: string) => string} deps.escapeHtml
  * @param {(msg: string, type?: string) => void} deps.setStatus
- * @param {{ current: Array<{ fullLayerId: string; displayName: string; submissionId: string; updatedAtLabel: string; colorRaw: string | null; infoTags: string[] }> }} deps.publishedCuratedLayersRef
+ * @param {{ current: Array<{ fullLayerId: string; displayName: string; submissionId: string; updatedAtRaw: string; colorRaw: string | null; infoTags: string[] }> }} deps.publishedCuratedLayersRef
  * @param {{ current: string | null }} deps.lastPublishedFullLayerIdRef
  * @param {(submissionId: string) => void} deps.selectSubmissionById
  * @param {(submissionId: string) => boolean} deps.submissionExists
@@ -237,7 +238,7 @@ export function createPublishedCuratedLayersPanel(deps) {
           resolveSubmissionIdByDisplayName?.(displayName) || "",
         ).trim().toLowerCase();
         const submissionId = sidFromGeo || sidFromTitle;
-        const updatedAtLabel = String(layer.updatedAtLabel || "—");
+        const updatedAtLabel = formatUpdatedAtForUi(layer.updatedAtRaw);
         const colorRaw = layer.colorRaw != null ? String(layer.colorRaw) : "";
         const geoColor = sanitizeCssColor(colorRaw);
         const listColor =

--- a/otef-interactive/frontend/src/curation/curation-published-layers.js
+++ b/otef-interactive/frontend/src/curation/curation-published-layers.js
@@ -2,12 +2,20 @@
  * Published curated layers list: load, render, unpublish, submission click-through.
  */
 
+import { t } from "../remote/remote-locale.js";
 import { sanitizeCssColor } from "./curation-color-utils.js";
 import {
   buildCurationColorSwatchHtml,
   chipClassForTag,
   getSubmissionTagLabels,
 } from "./curation-submissions.js";
+
+function displayCurationTagForPublishedList(tag) {
+  const s = String(tag);
+  if (s === "Tkuma Line") return t("curationTagTkumaLine");
+  if (s === "Memorials") return t("curationTagMemorials");
+  return s;
+}
 
 export function extractSubmissionIdsFromLayerData(layerData) {
   const ids = new Set();
@@ -71,13 +79,13 @@ export function getGeojsonDataFromGisLayerRecord(activeLayer) {
  * @param {string} merged
  */
 function submissionTypeLabelMergedIsRecognized(merged) {
-  const t = String(merged || "").trim().toLowerCase();
-  if (!t) return false;
-  if (t.includes("mixed") || t.includes("multiple")) return true;
-  if (t.includes("memorial")) return true;
-  if (t.includes("tkuma") || t.includes("moreshet")) return true;
-  if (t.includes("axis") || t.includes("route")) return true;
-  if (/\bline\b/.test(t)) return true;
+  const mergedLower = String(merged || "").trim().toLowerCase();
+  if (!mergedLower) return false;
+  if (mergedLower.includes("mixed") || mergedLower.includes("multiple")) return true;
+  if (mergedLower.includes("memorial")) return true;
+  if (mergedLower.includes("tkuma") || mergedLower.includes("moreshet")) return true;
+  if (mergedLower.includes("axis") || mergedLower.includes("route")) return true;
+  if (/\bline\b/.test(mergedLower)) return true;
   return false;
 }
 
@@ -207,7 +215,7 @@ export function createPublishedCuratedLayersPanel(deps) {
     return list
       .map((tag) => {
         const cls = chipClassForTag(tag);
-        return `<span class="${cls}">${escapeHtml(tag)}</span>`;
+        return `<span class="${cls}">${escapeHtml(displayCurationTagForPublishedList(tag))}</span>`;
       })
       .join("");
   }
@@ -217,7 +225,7 @@ export function createPublishedCuratedLayersPanel(deps) {
     if (!container) return;
     const publishedCuratedLayers = publishedCuratedLayersRef.current;
     if (!Array.isArray(publishedCuratedLayers) || publishedCuratedLayers.length === 0) {
-      container.innerHTML = '<div class="curation-status">No published curated layers.</div>';
+      container.innerHTML = '<div class="curation-status">' + t("curationNoPublishedLayers") + "</div>";
       return;
     }
     container.innerHTML = publishedCuratedLayers
@@ -242,27 +250,27 @@ export function createPublishedCuratedLayersPanel(deps) {
         );
         const swatch =
           swatchInner !== ""
-            ? `<span class="curation-published-layer-color" title="Submission color">${swatchInner}</span>`
+            ? `<span class="curation-published-layer-color" title="${escapeHtml(t("curationSubmissionColorTitle"))}">${swatchInner}</span>`
             : "";
         const chips = renderTagChips(layer.infoTags);
         const subName = submissionId ? String(getSubmissionDisplayName(submissionId) || "").trim() : "";
         const openLabel = submissionId
           ? subName
-            ? `Open submission ${subName} for published layer ${displayName}`
-            : `Open submission for published layer ${displayName}`
-          : `Published layer ${displayName}: submission unavailable (multiple or unknown); activates status message`;
+            ? t("curationOpenSubmissionForLayer", { e: subName, n: displayName })
+            : t("curationOpenSubmissionUnnamed", { e: displayName })
+          : t("curationPublishedLayerUnknown", { e: displayName });
         return `
           <div class="curation-published-layer-card" data-full-layer-id="${escapeHtml(fullLayerId)}">
             <div class="curation-published-layer-body">
               <button type="button" class="curation-published-layer-main curation-published-layer-select" data-submission-id="${escapeHtml(submissionId)}" aria-label="${escapeHtml(openLabel)}">
                 <div class="curation-published-layer-name">${escapeHtml(displayName)}</div>
                 <div class="curation-published-layer-meta-row">
-                  <span class="curation-published-layer-updated" title="Layer last updated">${escapeHtml(updatedAtLabel)}</span>
+                  <span class="curation-published-layer-updated" title="${escapeHtml(t("curationLayerUpdatedTitle"))}">${escapeHtml(updatedAtLabel)}</span>
                   ${swatch}
                 </div>
-                <div class="curation-published-layer-tags" aria-label="Layer type tags">${chips}</div>
+                <div class="curation-published-layer-tags" aria-label="${escapeHtml(t("curationLayerTypeTagsAria"))}">${chips}</div>
               </button>
-              <button type="button" class="curation-header-btn curation-published-layer-remove curation-unpublish-btn" data-full-layer-id="${escapeHtml(fullLayerId)}" aria-label="Remove layer from remote">Remove</button>
+              <button type="button" class="curation-header-btn curation-published-layer-remove curation-unpublish-btn" data-full-layer-id="${escapeHtml(fullLayerId)}" aria-label="${escapeHtml(t("curationUnpublishButtonAria"))}">${escapeHtml(t("curationUnpublishButton"))}</button>
             </div>
           </div>`;
       })
@@ -274,11 +282,11 @@ export function createPublishedCuratedLayersPanel(deps) {
           .trim()
           .toLowerCase();
         if (!sid) {
-          setStatus("This published layer maps to multiple/unknown submissions.", "error");
+          setStatus(t("curationMapUnknownSubmissions"), "error");
           return;
         }
         if (!submissionExists(sid)) {
-          setStatus(`Submission ${sid} is not available in the submissions list.`, "error");
+          setStatus(t("curationMapSubmissionNotInList", { e: sid }), "error");
           return;
         }
         selectSubmissionById(sid);
@@ -293,7 +301,7 @@ export function createPublishedCuratedLayersPanel(deps) {
         const ok =
           typeof window === "undefined" || !window.confirm
             ? true
-            : window.confirm(`Remove "${fullLayerId}" from published remote layers?`);
+            : window.confirm(t("curationUnpublishOneConfirm", { e: fullLayerId }));
         if (!ok) return;
         btn.disabled = true;
         try {
@@ -304,10 +312,10 @@ export function createPublishedCuratedLayersPanel(deps) {
           if (lastPublishedFullLayerIdRef.current === fullLayerId) {
             lastPublishedFullLayerIdRef.current = null;
           }
-          setStatus(`Removed "${fullLayerId}" from published remote layers.`, "success");
+          setStatus(t("curationUnpublishOneSuccess", { e: fullLayerId }), "success");
           await loadPublishedCuratedLayers();
         } catch (err) {
-          setStatus("Could not remove published layer: " + (err?.message || String(err)), "error");
+          setStatus(t("curationUnpublishOneError", { e: err?.message || String(err) }), "error");
           btn.disabled = false;
         }
       });
@@ -317,7 +325,7 @@ export function createPublishedCuratedLayersPanel(deps) {
   async function loadPublishedCuratedLayers() {
     const container = publishedLayersContainer();
     if (!container) return;
-    container.innerHTML = '<div class="curation-status">Loading published curated layers…</div>';
+    container.innerHTML = '<div class="curation-status">' + t("curationLoadingPublished") + "</div>";
     try {
       const state = await API.layerGroups("otef");
       const activeLayers = await API.activeGisLayers("otef");
@@ -365,7 +373,7 @@ export function createPublishedCuratedLayersPanel(deps) {
       renderPublishedCuratedLayers();
     } catch (err) {
       publishedCuratedLayersRef.current = [];
-      container.innerHTML = `<div class="curation-status error">Could not load published curated layers: ${escapeHtml(err?.message || String(err))}</div>`;
+      container.innerHTML = `<div class="curation-status error">${escapeHtml(t("curationLoadPublishedError", { e: err?.message || String(err) }))}</div>`;
     }
   }
 

--- a/otef-interactive/frontend/src/curation/curation-submissions.js
+++ b/otef-interactive/frontend/src/curation/curation-submissions.js
@@ -2,6 +2,7 @@
  * Searchable submissions combobox (Supabase all-submissions API).
  */
 
+import { t } from "../remote/remote-locale.js";
 import { sanitizeCssColor } from "./curation-color-utils.js";
 import {
   normalizeSubmissionDisplayColorHex,
@@ -34,9 +35,9 @@ export function buildCurationColorSwatchHtml(colorCss, baseClasses) {
       : null;
   if (normalizedPrimary != null && secondary != null) {
     const partner = secondary || "#94A3B8";
-    return `<span class="${baseClasses} curation-submission-swatch-dot" style="--swatch-primary:${escapeHtml(normalizedPrimary)};--swatch-secondary:${escapeHtml(partner)};" title="Submission color" aria-hidden="true"></span>`;
+    return `<span class="${baseClasses} curation-submission-swatch-dot" style="--swatch-primary:${escapeHtml(normalizedPrimary)};--swatch-secondary:${escapeHtml(partner)};" title="${escapeHtml(t("curationSubmissionColorTitle"))}" aria-hidden="true"></span>`;
   }
-  return `<span class="${baseClasses}" style="background-color:${escapeHtml(colorCss)}" title="Submission color" aria-hidden="true"></span>`;
+  return `<span class="${baseClasses}" style="background-color:${escapeHtml(colorCss)}" title="${escapeHtml(t("curationSubmissionColorTitle"))}" aria-hidden="true"></span>`;
 }
 
 /**
@@ -45,9 +46,9 @@ export function buildCurationColorSwatchHtml(colorCss, baseClasses) {
  * @param {string} tagLabel
  */
 export function chipClassForTag(tagLabel) {
-  const t = String(tagLabel || "").trim().toLowerCase();
-  if (t === "memorials") return "curation-chip curation-chip-type type-memorial";
-  if (t === "tkuma line") return "curation-chip curation-chip-type type-moreshet";
+  const s = String(tagLabel || "").trim().toLowerCase();
+  if (s === "memorials") return "curation-chip curation-chip-type type-memorial";
+  if (s === "tkuma line") return "curation-chip curation-chip-type type-moreshet";
   return "curation-chip";
 }
 
@@ -95,12 +96,19 @@ function normalizeSubmissionRow(raw) {
   return { id, name, typeLabel, hasHistory, colorRaw, colorCss, raw };
 }
 
+function displayCurationTypeTagForUi(tag) {
+  const s = String(tag);
+  if (s === "Tkuma Line") return t("curationTagTkumaLine");
+  if (s === "Memorials") return t("curationTagMemorials");
+  return s;
+}
+
 function renderOptionChipsHtml(row) {
   const tags = getSubmissionTagLabels(row);
   return tags
     .map((tag) => {
       const cls = chipClassForTag(tag);
-      return `<span class="${cls}">${escapeHtml(tag)}</span>`;
+      return `<span class="${cls}">${escapeHtml(displayCurationTypeTagForUi(tag))}</span>`;
     })
     .join("");
 }
@@ -167,19 +175,19 @@ export function createSubmissionsPanel(deps) {
 
   /** Match curated GIS display_name to the submissions list row (GeoJSON may omit submission_id). */
   function findSubmissionIdByDisplayName(displayName) {
-    const t = String(displayName || "").trim().toLowerCase();
-    if (!t) return null;
-    const row = submissions.find((s) => String(s.name || "").trim().toLowerCase() === t);
+    const nameKey = String(displayName || "").trim().toLowerCase();
+    if (!nameKey) return null;
+    const row = submissions.find((s) => String(s.name || "").trim().toLowerCase() === nameKey);
     return row ? row.id : null;
   }
 
   function matchesFilter(row, q) {
-    const t = String(q || "").trim().toLowerCase();
-    if (!t) return true;
-    if (row.name.toLowerCase().includes(t) || row.id.toLowerCase().includes(t)) {
+    const queryLower = String(q || "").trim().toLowerCase();
+    if (!queryLower) return true;
+    if (row.name.toLowerCase().includes(queryLower) || row.id.toLowerCase().includes(queryLower)) {
       return true;
     }
-    return getSubmissionTagLabels(row).some((tag) => tag.toLowerCase().includes(t));
+    return getSubmissionTagLabels(row).some((tag) => tag.toLowerCase().includes(queryLower));
   }
 
   function setListOpen(open) {
@@ -245,7 +253,9 @@ export function createSubmissionsPanel(deps) {
     if (rows.length === 0) {
       list.innerHTML =
         '<div class="curation-status">' +
-        (submissions.length === 0 ? "No submissions loaded." : "No matching submissions.") +
+        (submissions.length === 0
+          ? t("curationSubmissionsEmpty")
+          : t("curationSubmissionsNoMatch")) +
         "</div>";
       return;
     }
@@ -337,9 +347,9 @@ export function createSubmissionsPanel(deps) {
 
     const onDocPointerDown = (e) => {
       if (!listOpen) return;
-      const t = e.target;
-      if (!t) return;
-      if (root && root.contains(t)) return;
+      const evTarget = e.target;
+      if (!evTarget) return;
+      if (root && root.contains(evTarget)) return;
       setListOpen(false);
       syncInputDisplayFromSelection();
     };
@@ -375,7 +385,7 @@ export function createSubmissionsPanel(deps) {
     const input = getSelectedIdInput();
     if (!list || !input) return;
     const prev = normSubmissionId(input.value || "");
-    list.innerHTML = '<div class="curation-status">Loading submissions…</div>';
+    list.innerHTML = '<div class="curation-status">' + t("curationSubmissionsLoading") + "</div>";
     submissionTypeById.clear();
     try {
       const rawList = await API.submissionsAll();
@@ -419,7 +429,7 @@ export function createSubmissionsPanel(deps) {
         }
       } else {
         submissions = [];
-        setStatus("Could not load submissions: " + (e?.message || String(e)), "error");
+        setStatus(t("curationSubmissionsLoadError", { e: e?.message || String(e) }), "error");
         input.value = "";
         selectedSubmission = null;
         renderList();
@@ -433,6 +443,11 @@ export function createSubmissionsPanel(deps) {
     }
   }
 
+  function rerenderForLocale() {
+    renderList();
+    syncInputDisplayFromSelection();
+  }
+
   return {
     loadSubmissions,
     selectSubmissionById,
@@ -441,5 +456,6 @@ export function createSubmissionsPanel(deps) {
     getSubmissionDisplayName,
     getSubmissionColorCss,
     findSubmissionIdByDisplayName,
+    rerenderForLocale,
   };
 }

--- a/otef-interactive/frontend/src/curation/curation-submissions.js
+++ b/otef-interactive/frontend/src/curation/curation-submissions.js
@@ -15,9 +15,17 @@ function normSubmissionId(id) {
 }
 
 function escapeHtml(s) {
-  const div = document.createElement("div");
-  div.textContent = s == null ? "" : String(s);
-  return div.innerHTML;
+  if (typeof document !== "undefined" && typeof document.createElement === "function") {
+    const div = document.createElement("div");
+    div.textContent = s == null ? "" : String(s);
+    return div.innerHTML;
+  }
+  return String(s == null ? "" : s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 /**
@@ -171,6 +179,18 @@ export function createSubmissionsPanel(deps) {
     const k = normSubmissionId(id);
     const row = submissions.find((s) => s.id === k);
     return row?.colorCss ?? null;
+  }
+
+  /**
+   * Same `type_label` string as the combobox row (for `getSubmissionTagLabels` parity with published list).
+   * @param {string} id
+   * @returns {string | null} null if unknown / not in current list
+   */
+  function getSubmissionTypeLabel(id) {
+    const k = normSubmissionId(id);
+    if (!k) return null;
+    if (!submissionTypeById.has(k)) return null;
+    return submissionTypeById.get(k) ?? null;
   }
 
   /** Match curated GIS display_name to the submissions list row (GeoJSON may omit submission_id). */
@@ -455,6 +475,7 @@ export function createSubmissionsPanel(deps) {
     hasSubmissionId,
     getSubmissionDisplayName,
     getSubmissionColorCss,
+    getSubmissionTypeLabel,
     findSubmissionIdByDisplayName,
     rerenderForLocale,
   };

--- a/otef-interactive/frontend/src/curation/curation.js
+++ b/otef-interactive/frontend/src/curation/curation.js
@@ -53,6 +53,8 @@ export { createCurationPreviewState } from "./curation-state.js";
       submissionsCtlRef.current?.getSubmissionDisplayName?.(id) ?? "",
     getSubmissionColorCss: (id) =>
       submissionsCtlRef.current?.getSubmissionColorCss?.(id) ?? null,
+    getSubmissionTypeLabel: (id) =>
+      submissionsCtlRef.current?.getSubmissionTypeLabel?.(id) ?? null,
     resolveSubmissionIdByDisplayName: (displayName) =>
       submissionsCtlRef.current?.findSubmissionIdByDisplayName?.(displayName) ?? null,
   });

--- a/otef-interactive/frontend/src/curation/curation.js
+++ b/otef-interactive/frontend/src/curation/curation.js
@@ -1,3 +1,4 @@
+import { LOCALE_EVENT, t } from "../remote/remote-locale.js";
 import { createCurationApi } from "./curation-api.js";
 import { buildPublishGeojsonFromApiFeatures } from "./curation-publish-geojson.js";
 import { createPublishedCuratedLayersPanel } from "./curation-published-layers.js";
@@ -102,13 +103,13 @@ export { createCurationPreviewState } from "./curation-state.js";
     const sid = selectedSubmissionId();
     const name = getPublishLayerNameFromSelection();
     if (!sid || !name) {
-      setStatus("Select a submission to publish.", "error");
+      setStatus(t("curationSelectSubmissionError"), "error");
       return;
     }
 
     const projName = getSelectedProjectName();
     if (!projName) {
-      setStatus("Missing curated group name.", "error");
+      setStatus(t("curationMissingGroupError"), "error");
       return;
     }
 
@@ -133,13 +134,13 @@ export { createCurationPreviewState } from "./curation-state.js";
         Object.keys(featureStamp).length ? featureStamp : undefined,
       );
       if (!selected.features.length) {
-        setStatus("No current features to publish for this submission.", "error");
+        setStatus(t("curationNoFeaturesError"), "error");
         return;
       }
 
       const pb = publishBtn();
       if (pb) pb.disabled = true;
-      setStatus("Publishing…");
+      setStatus(t("curationPublishing"));
 
       let payload = {
         ...selected,
@@ -175,13 +176,13 @@ export { createCurationPreviewState } from "./curation-state.js";
       const result = await API.publish(name, payload, projName);
       lastPublishedFullLayerIdRef.current = result.fullLayerId || null;
       await publishedPanel.loadPublishedCuratedLayers();
-      setStatus('Published "' + (result.displayName || name) + '".', "success");
+      setStatus(t("curationPublishedSuccess", { e: result.displayName || name }), "success");
     } catch (e) {
       const msg = (e && e.message) || (e && typeof e === "object" && e.toString && e.toString()) || String(e) || "Unknown error";
       if (typeof console !== "undefined" && console.error) {
         console.error("[Curation] Publish failed:", e);
       }
-      setStatus("Publish failed: " + msg, "error");
+      setStatus(t("curationPublishFailed", { e: msg }), "error");
     } finally {
       isPublishing = false;
       updatePublishState();
@@ -196,25 +197,25 @@ export { createCurationPreviewState } from "./curation-state.js";
     const ok =
       typeof window === "undefined" || !window.confirm
         ? true
-        : window.confirm("Remove all published curated layers from the remote?");
+        : window.confirm(t("curationUnpublishAllConfirm"));
     if (!ok) return;
     const btn = el("curationUnpublishAll");
     if (btn) btn.disabled = true;
-    setStatus("Removing all published curated layers…");
+    setStatus(t("curationUnpublishAllInProgress"));
     try {
       const body = await API.unpublishAllCuratedLayers({ table: CURATION_TABLE });
       lastPublishedFullLayerIdRef.current = null;
       const n = body.removed_count;
       setStatus(
         typeof n === "number"
-          ? `Removed ${n} published layer(s) from remote.`
-          : "All published curated layers removed from remote.",
+          ? t("curationUnpublishAllRemovedN", { n })
+          : t("curationUnpublishAllSuccess"),
         "success",
       );
       await publishedPanel.loadPublishedCuratedLayers();
       await submissionsCtlRef.current.loadSubmissions({ preserveOnError: true });
     } catch (err) {
-      setStatus("Could not unpublish all: " + (err?.message || String(err)), "error");
+      setStatus(t("curationUnpublishAllError", { e: err?.message || String(err) }), "error");
     } finally {
       if (btn) btn.disabled = false;
     }
@@ -228,7 +229,7 @@ export { createCurationPreviewState } from "./curation-state.js";
       const on = await API.getWorkshopMode(CURATION_TABLE);
       input.checked = on;
     } catch (e) {
-      setStatus("Could not load workshop mode: " + (e?.message || String(e)), "error");
+      setStatus(t("curationLoadWorkshopError", { e: e?.message || String(e) }), "error");
       input.checked = false;
     } finally {
       input.disabled = false;
@@ -243,14 +244,12 @@ export { createCurationPreviewState } from "./curation-state.js";
     try {
       await API.setWorkshopMode(next, CURATION_TABLE);
       setStatus(
-        next
-          ? "Workshop auto-publish is on: new submissions can publish automatically when eligible."
-          : "Workshop auto-publish is off.",
+        next ? t("curationWorkshopOnSuccess") : t("curationWorkshopOffSuccess"),
         "success",
       );
     } catch (e) {
       input.checked = !next;
-      setStatus("Could not update workshop mode: " + (e?.message || String(e)), "error");
+      setStatus(t("curationUpdateWorkshopError", { e: e?.message || String(e) }), "error");
     } finally {
       input.disabled = false;
     }
@@ -281,6 +280,14 @@ export { createCurationPreviewState } from "./curation-state.js";
       void onWorkshopModeToggle();
     });
     refreshBtn()?.addEventListener("click", refresh);
+    el("curationSubmissionsRefresh")?.addEventListener("click", refresh);
+
+    if (typeof window !== "undefined") {
+      window.addEventListener(LOCALE_EVENT, () => {
+        submissionsCtlRef.current?.rerenderForLocale?.();
+        publishedPanel.renderPublishedCuratedLayers();
+      });
+    }
   }
 
   if (typeof document !== "undefined") {

--- a/otef-interactive/frontend/src/entries/curation-main.js
+++ b/otef-interactive/frontend/src/entries/curation-main.js
@@ -15,6 +15,8 @@ function ensureItmProjection() {
 async function boot() {
   ensureItmProjection();
   await import("../map-utils/coordinate-utils.js");
+  const { initLocale } = await import("../remote/remote-locale.js");
+  initLocale();
   // `?embed=1`: parent remote-controller owns heartbeat; `startCuratedSupabaseHeartbeat` no-ops when `curation-embed` detects embed mode.
   await import("../curation/curation.js");
 }

--- a/otef-interactive/frontend/src/entries/curation-main.js
+++ b/otef-interactive/frontend/src/entries/curation-main.js
@@ -15,6 +15,7 @@ function ensureItmProjection() {
 async function boot() {
   ensureItmProjection();
   await import("../map-utils/coordinate-utils.js");
+  // `?embed=1`: parent remote-controller owns heartbeat; `startCuratedSupabaseHeartbeat` no-ops when `curation-embed` detects embed mode.
   await import("../curation/curation.js");
 }
 

--- a/otef-interactive/frontend/src/entries/remote-main.js
+++ b/otef-interactive/frontend/src/entries/remote-main.js
@@ -1,4 +1,5 @@
 import TableSwitcher from "../shared/table-switcher.js";
+import { initLocale } from "../remote/remote-locale.js";
 
 async function bootstrapRemoteRuntime() {
   const modules = [
@@ -49,6 +50,7 @@ function initializeTableSwitcher() {
 }
 
 async function boot() {
+  initLocale();
   const shouldContinue = initializeTableSwitcher();
   if (!shouldContinue) return;
   await bootstrapRemoteRuntime();

--- a/otef-interactive/frontend/src/remote/layer-pack-display-names.js
+++ b/otef-interactive/frontend/src/remote/layer-pack-display-names.js
@@ -8,13 +8,35 @@
 const PACK_LABELS = {
   october_7th: { he: "7 באוקטובר", en: "October 7th" },
   projector_base: { he: "מקרן בסיס", en: "Projector base" },
+  map_3_future: { he: "מפה 3 — עתיד", en: "Map 3 — future" },
+  curated_moresht_axis: { he: "ציר מורשת (אוצרות)", en: "Moreshet axis (curated)" },
+  future_development: { he: "פיתוח עתידי", en: "Future development" },
+  municipality_transport: { he: "תחבורה מוניציפלית", en: "Municipal transport" },
+  // Common GIS / hand-entry typo seen next to the canonical id
+  municpality_transport: { he: "תחבורה מוניציפלית", en: "Municipal transport" },
 };
 
 export const REQUIRED_PACK_IDS = /** @type {const} */ ([
   "october_7th",
   "projector_base",
+  "map_3_future",
+  "curated_moresht_axis",
+  "future_development",
+  "municipality_transport",
+  "municpality_transport",
   "curated",
 ]);
+
+/**
+ * @param {string} id
+ * @returns {string}
+ */
+export function normalizePackId(id) {
+  return String(id)
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
 
 /**
  * @param {string} packId
@@ -22,11 +44,15 @@ export const REQUIRED_PACK_IDS = /** @type {const} */ ([
  * @returns {string | null}
  */
 export function getPackDisplayLabel(packId, locale) {
-  if (packId === "curated") {
+  const idStr = String(packId);
+  if (idStr === "curated" || normalizePackId(idStr) === "curated") {
     return null;
   }
   const loc = locale === "en" ? "en" : "he";
-  const row = PACK_LABELS[packId];
+  let row = PACK_LABELS[idStr];
+  if (!row) {
+    row = PACK_LABELS[normalizePackId(idStr)];
+  }
   if (!row) {
     return null;
   }

--- a/otef-interactive/frontend/src/remote/layer-pack-display-names.js
+++ b/otef-interactive/frontend/src/remote/layer-pack-display-names.js
@@ -1,0 +1,35 @@
+/**
+ * Human-readable pack titles for known stable group ids. Curated is intentionally
+ * not mapped here so `layerGroupTitle` uses `t("curatedGroupLabel")` only.
+ *
+ * @typedef {"he" | "en"} PackDisplayLocale
+ */
+
+const PACK_LABELS = {
+  october_7th: { he: "7 באוקטובר", en: "October 7th" },
+  projector_base: { he: "מקרן בסיס", en: "Projector base" },
+};
+
+export const REQUIRED_PACK_IDS = /** @type {const} */ ([
+  "october_7th",
+  "projector_base",
+  "curated",
+]);
+
+/**
+ * @param {string} packId
+ * @param {PackDisplayLocale} locale
+ * @returns {string | null}
+ */
+export function getPackDisplayLabel(packId, locale) {
+  if (packId === "curated") {
+    return null;
+  }
+  const loc = locale === "en" ? "en" : "he";
+  const row = PACK_LABELS[packId];
+  if (!row) {
+    return null;
+  }
+  const label = row[loc];
+  return label != null && String(label).trim() !== "" ? String(label) : null;
+}

--- a/otef-interactive/frontend/src/remote/layer-pack-display-names.js
+++ b/otef-interactive/frontend/src/remote/layer-pack-display-names.js
@@ -7,13 +7,18 @@
 
 const PACK_LABELS = {
   october_7th: { he: "7 באוקטובר", en: "October 7th" },
-  projector_base: { he: "מקרן בסיס", en: "Projector base" },
+  projector_base: { he: "בסיס מקרן", en: "Projector base" },
   map_3_future: { he: "מפה 3 — עתיד", en: "Map 3 — future" },
-  curated_moresht_axis: { he: "ציר מורשת (אוצרות)", en: "Moreshet axis (curated)" },
+  curated_moresht_axis: { he: "סדנה", en: "Workshop" },
   future_development: { he: "פיתוח עתידי", en: "Future development" },
+  gaza: { he: "עזה", en: "Gaza" },
+  greens: { he: "ירוקים", en: "Greens" },
+  land_use: { he: "שימושי קרקע", en: "Land use" },
   municipality_transport: { he: "תחבורה מוניציפלית", en: "Municipal transport" },
   // Common GIS / hand-entry typo seen next to the canonical id
   municpality_transport: { he: "תחבורה מוניציפלית", en: "Municipal transport" },
+  // layers-manifest id (spelling in data / registry)
+  muniplicity_transport: { he: "תחבורה מוניציפלית", en: "Municipal transport" },
 };
 
 export const REQUIRED_PACK_IDS = /** @type {const} */ ([
@@ -22,8 +27,12 @@ export const REQUIRED_PACK_IDS = /** @type {const} */ ([
   "map_3_future",
   "curated_moresht_axis",
   "future_development",
+  "gaza",
+  "greens",
+  "land_use",
   "municipality_transport",
   "municpality_transport",
+  "muniplicity_transport",
   "curated",
 ]);
 

--- a/otef-interactive/frontend/src/remote/layer-sheet-controller.js
+++ b/otef-interactive/frontend/src/remote/layer-sheet-controller.js
@@ -1,16 +1,16 @@
 /**
  * Layer list controller (Layers tab)
  *
- * **Sharpened Variant C:** pack chip strip (single selection) + per-pack count row +
+ * **Sharpened Variant C:** pack chip strip (single selection) + per-pack count on each chip +
  * one bulk-visibility control for the selected pack + tile grid (per-layer on/off, animation
  * icon button on tile only). Syncs with OTEFDataContext.
  */
 
 import {
-  formatLayerLabelForDisplay,
   normalizeLayerBaseName,
   parseLayerNameWithGeometrySuffix,
 } from "../shared/layer-name-utils.js";
+import { getLayerDisplayLabel } from "../shared/layer-display-glossary.js";
 import {
   LOCALE_EVENT,
   applyRemoteChromeI18n,
@@ -140,12 +140,67 @@ function encAttrId(id) {
   return encodeURIComponent(String(id));
 }
 
-/** @param {string} value @param {string} fallback */
-function clampPreviewColor(value, fallback = "#808080") {
-  if (typeof value !== "string" || !/^#[0-9a-fA-F]{6}$/.test(value.trim())) {
-    return fallback;
+const HEB_RANGE_RE = /[\u0590-\u05FF]/;
+
+/**
+ * @param {unknown} s
+ * @returns {boolean}
+ */
+function isLatinPrimaryString(s) {
+  if (s == null) return false;
+  const t = String(s);
+  if (t.trim() === "") return false;
+  return /[A-Za-z]/.test(t) && !HEB_RANGE_RE.test(t);
+}
+
+/**
+ * Raw label for glossary resolution: English UI prefers a Latin-primary name from
+ * `row.layers` when the row-level label is Hebrew-only; Hebrew UI keeps row-level
+ * precedence for Hebrew-friendly copy.
+ *
+ * @param {object} row
+ * @param {"he" | "en"} locale
+ * @returns {string}
+ */
+function pickRawLabelForRow(row, locale) {
+  if (locale === "en" && row && Array.isArray(row.layers)) {
+    for (const layer of row.layers) {
+      if (!layer) continue;
+      const candidates = [layer.displayName, layer.name].filter(
+        (v) => v != null && String(v).trim() !== "",
+      );
+      for (const c of candidates) {
+        if (isLatinPrimaryString(c)) {
+          return String(c);
+        }
+      }
+    }
   }
-  return value.trim();
+  return (
+    row.displayLabel ??
+    row.baseName ??
+    row.layers[0]?.name ??
+    row.layers[0]?.id ??
+    ""
+  );
+}
+
+/**
+ * Label string used for `renderLayerRow` (sorting tile order by length).
+ * @param {object} row
+ * @returns {string}
+ */
+function getRowDisplayLabelForSort(row) {
+  const loc = getLocale();
+  const rawLabel = pickRawLabelForRow(row, loc);
+  return getLayerDisplayLabel(
+    row.fullLayerIds && row.fullLayerIds[0] != null
+      ? String(row.fullLayerIds[0])
+      : "",
+    loc,
+    rawLabel,
+    row.fullLayerIds,
+  );
 }
 
 /**
@@ -166,19 +221,15 @@ function renderLayerRow(row, options = {}) {
     /"/g,
     "&quot;",
   );
-  const rawLabel =
-    row.displayLabel ?? row.baseName ?? row.layers[0]?.name ?? row.layers[0]?.id ?? "";
-  const label = formatLayerLabelForDisplay(rawLabel);
-  const previewRaw = options.stylePreview || {
-    fillColor: "#808080",
-    fillOpacity: 0.7,
-    strokeColor: "#000000",
-  };
-  const preview = {
-    ...previewRaw,
-    fillColor: clampPreviewColor(previewRaw.fillColor),
-    strokeColor: clampPreviewColor(previewRaw.strokeColor),
-  };
+  const rawLabel = pickRawLabelForRow(row, getLocale());
+  const label = getLayerDisplayLabel(
+    row.fullLayerIds && row.fullLayerIds[0] != null
+      ? String(row.fullLayerIds[0])
+      : "",
+    getLocale(),
+    rawLabel,
+    row.fullLayerIds,
+  );
   const animatableIds = getRowAnimatableFullLayerIds(row, groupId);
   const hasAnimationToggle = animatableIds.length > 0;
   const animIdsAttr = JSON.stringify(animatableIds).replace(/"/g, "&quot;");
@@ -201,6 +252,7 @@ function renderLayerRow(row, options = {}) {
   const primaryClass = isPrimary ? " layer-tile--primary" : "";
   const visibleClass =
     checked && !isPrimary ? " is-visible" : "";
+  const animTileClass = hasAnimationToggle ? " layer-tile--anim" : "";
   const animStateClass = `${animationEnabled ? "active" : ""} ${
     animationMixed ? "mixed" : ""
   }`.trim();
@@ -213,16 +265,15 @@ function renderLayerRow(row, options = {}) {
         data-animation-layer-ids="${animIdsAttr}"
         data-i18n-aria="ariaLayerAnimationToggle"
       >${playIcon}</button>`
-    : `<span class="anim-btn anim-btn--absent" aria-hidden="true"></span>`;
+    : "";
   return `
     <div
-      class="layer-tile ${stateClass}${visibleClass}${primaryClass}"
+      class="layer-tile ${stateClass}${visibleClass}${primaryClass}${animTileClass}"
       tabindex="0"
       aria-pressed="${checked ? "true" : "false"}"
       aria-label="${escapeHtmlSafe(label)}"
       data-layer-ids="${layerIdsAttr}"
     >
-      <div class="layer-tile__preview" style="background-color: ${preview.fillColor}; opacity: ${preview.fillOpacity}; border-color: ${preview.strokeColor};"></div>
       <span class="layer-tile__label">${escapeHtmlSafe(label)}</span>
       ${animControl}
     </div>
@@ -280,15 +331,6 @@ class LayerSheetController {
   }
 
   setupEventListeners() {
-    const back = document.getElementById("layerPanelBack");
-    if (back) {
-      // Clears primary-tile emphasis only; selected pack stays (see `clearLayerFocus`).
-      back.addEventListener("click", (e) => {
-        e.preventDefault();
-        this.clearLayerFocus();
-      });
-    }
-
     const content = this.sheet.querySelector(".sheet-content");
     if (!content) return;
 
@@ -383,6 +425,7 @@ class LayerSheetController {
   /**
    * Drop primary-tile highlight (`primaryTileIdsJson`). Does not change the selected
    * pack; `render()` keeps a valid pack via `resolveSelectedPackId`.
+   * (Previously wired to #layerPanelBack; that control was removed — kept for API use.)
    */
   clearLayerFocus() {
     this.primaryTileIdsJson = null;
@@ -560,40 +603,23 @@ class LayerSheetController {
             layers: [layer],
             enabled: layer.enabled,
           }));
+    rows.sort((a, b) => {
+      const la = getRowDisplayLabelForSort(a).length;
+      const lb = getRowDisplayLabelForSort(b).length;
+      if (la !== lb) return la - lb;
+      const ka = layerIdsToPrimaryKey(a.fullLayerIds) || "";
+      const kb = layerIdsToPrimaryKey(b.fullLayerIds) || "";
+      return ka.localeCompare(kb);
+    });
     return rows
-      .map((row) => {
-        const style = this.getLayerStylePreview(row.layers[0]);
-        return renderLayerRow(row, {
+      .map((row) =>
+        renderLayerRow(row, {
           groupId: group.id,
-          stylePreview: style,
           animations: anims,
           primaryTileIdsJson: this.primaryTileIdsJson,
-        });
-      })
+        }),
+      )
       .join("");
-  }
-
-  getLayerStylePreview(layer) {
-    if (!layer) {
-      return {
-        fillColor: "#808080",
-        fillOpacity: 0.7,
-        strokeColor: "#000000",
-      };
-    }
-    if (layer.format === "image" || layer.geometryType === "image") {
-      return {
-        fillColor: "#4a90e2",
-        fillOpacity: 0.8,
-        strokeColor: "#2a5a8a",
-      };
-    }
-
-    return {
-      fillColor: "#808080",
-      fillOpacity: 0.7,
-      strokeColor: "#000000",
-    };
   }
 
   /**
@@ -622,49 +648,53 @@ class LayerSheetController {
     if (!selected) {
       return `<div class="sheet-empty">${escapeHtmlSafe(t("layerEmpty"))}</div>`;
     }
-    const enabledLayers = (selected.layers || []).filter((l) => l.enabled).length;
-    const totalLayers = (selected.layers || []).length;
     const encGid = encAttrId(selected.id);
-    const packCountText = t("layersPackActiveCount", {
-      e: enabledLayers,
-      t: totalLayers,
-    });
 
-    const chips = groups
-      .map((g) => {
-        const enc = encAttrId(g.id);
-        const isSel = g.id === selectedId;
-        const currentAttr = isSel ? ' aria-current="true"' : "";
-        return `<button
+    const chipForGroup = (g) => {
+      const enc = encAttrId(g.id);
+      const isSel = g.id === selectedId;
+      const currentAttr = isSel ? ' aria-current="true"' : "";
+      const en = (g.layers || []).filter((l) => l.enabled).length;
+      const to = (g.layers || []).length;
+      const countStr = t("layersPackActiveCount", { e: en, t: to });
+      const title = layerGroupTitle(g);
+      return `<button
           type="button"
           class="pack-chip${isSel ? " pack-chip--selected" : ""}"
           data-layers-select-pack="${enc}"${currentAttr}
-        >${escapeHtmlSafe(layerGroupTitle(g))}</button>`;
-      })
-      .join("");
+        >${escapeHtmlSafe(title)}<span class="group-count">${escapeHtmlSafe(countStr)}</span></button>`;
+    };
+    const mid = Math.ceil(groups.length / 2);
+    const row1 = groups.slice(0, mid).map(chipForGroup).join("");
+    const row2 = groups.slice(mid).map(chipForGroup).join("");
 
     return `
     <div class="layers-variant-c">
       <div
         class="layers-pack-strip-wrap"
         role="region"
-        data-i18n-aria="ariaLayersPackStrip"
       >
-        <div class="layers-pack-head">
-          <p class="layers-pack-head__label" data-i18n="layersPackStripLabel">${escapeHtmlSafe(t("layersPackStripLabel"))}</p>
-          <span class="group-count" aria-hidden="true">${escapeHtmlSafe(packCountText)}</span>
-        </div>
         <div class="layers-pack-strip">
           <div class="layers-pack-strip__viewport">
             <div class="layers-pack-strip__edge layers-pack-strip__edge--start" aria-hidden="true"></div>
             <div class="layers-pack-strip__edge layers-pack-strip__edge--end" aria-hidden="true"></div>
             <div class="layers-pack-strip__scroller">
-              ${chips}
+              <div class="layers-pack-strip__band">
+                <div class="layers-pack-strip__row">${row1}</div>
+                <div class="layers-pack-strip__row">${row2}</div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-      <p class="layers-pack-scroll-hint" data-i18n="layersPackScrollHint">${escapeHtmlSafe(t("layersPackScrollHint"))}</p>
+      <div class="layers-active-summary" role="status">
+        <span
+          class="layer-count"
+          data-i18n="layersActiveCount"
+          data-i18n-n="0"
+          id="layerPanelCount"
+        ></span>
+      </div>
       <div class="focused-pack-toolbar">
         <span class="focused-pack-toolbar__label" data-i18n="layersBulkVisibility">${escapeHtmlSafe(t("layersBulkVisibility"))}</span>
         <label class="group-toggle layer-bulk-visibility">
@@ -692,17 +722,10 @@ class LayerSheetController {
       return sum + (group.layers || []).filter((l) => l.enabled).length;
     }, 0);
 
-    const countEl = this.sheet.querySelector(".layer-count");
+    const countEl = document.getElementById("layerPanelCount");
     if (countEl) {
       countEl.setAttribute("data-i18n-n", String(totalEnabled));
       countEl.textContent = formatActiveLayerCount(totalEnabled);
-    }
-
-    const back = document.getElementById("layerPanelBack");
-    if (back) back.hidden = true;
-    const titleEl = document.getElementById("layerPanelTitle");
-    if (titleEl) {
-      titleEl.setAttribute("data-i18n", "layerSheetTitle");
     }
   }
 
@@ -717,8 +740,6 @@ class LayerSheetController {
       this.focusedGroupId = this.resolveSelectedPackId(groups);
     }
 
-    this.updatePanelChrome(groups);
-
     const animations =
       typeof OTEFDataContext !== "undefined" &&
       typeof OTEFDataContext.getAnimations === "function"
@@ -726,7 +747,18 @@ class LayerSheetController {
         : {};
 
     if (groups.length === 0) {
-      content.innerHTML = `<div class="sheet-empty">${escapeHtmlSafe(t("layerEmpty"))}</div>`;
+      content.innerHTML = `
+    <div class="layers-variant-c layers-variant-c--empty">
+      <div class="layers-active-summary" role="status">
+        <span
+          class="layer-count"
+          data-i18n="layersActiveCount"
+          data-i18n-n="0"
+          id="layerPanelCount"
+        ></span>
+      </div>
+      <div class="sheet-empty">${escapeHtmlSafe(t("layerEmpty"))}</div>
+    </div>`;
     } else {
       content.innerHTML = this.renderLayersTabContent(groups, animations);
       const selectedId = this.focusedGroupId;
@@ -741,6 +773,8 @@ class LayerSheetController {
         }
       }
     }
+
+    this.updatePanelChrome(groups);
     applyRemoteChromeI18n();
   }
 }

--- a/otef-interactive/frontend/src/remote/layer-sheet-controller.js
+++ b/otef-interactive/frontend/src/remote/layer-sheet-controller.js
@@ -19,6 +19,55 @@ import {
   t,
 } from "./remote-locale.js";
 import { getPackDisplayLabel } from "./layer-pack-display-names.js";
+import { sanitizeCssColor } from "../curation/curation-color-utils.js";
+import { createCurationApi } from "../curation/curation-api.js";
+import { buildCurationColorSwatchHtml } from "../curation/curation-submissions.js";
+
+const workshopSubmissionColorById = new Map();
+const workshopSubmissionColorByName = new Map();
+let workshopSubmissionColorsLoaded = false;
+let workshopSubmissionColorsLoading = null;
+
+function normSubmissionKey(v) {
+  return String(v ?? "").trim().toLowerCase();
+}
+
+async function ensureWorkshopSubmissionColorsLoaded() {
+  if (workshopSubmissionColorsLoaded) return;
+  if (workshopSubmissionColorsLoading) {
+    await workshopSubmissionColorsLoading;
+    return;
+  }
+  workshopSubmissionColorsLoading = (async () => {
+    try {
+      const API = createCurationApi();
+      const list = await API.submissionsAll();
+      workshopSubmissionColorById.clear();
+      workshopSubmissionColorByName.clear();
+      for (const item of Array.isArray(list) ? list : []) {
+        if (!item || typeof item !== "object") continue;
+        const idKey = normSubmissionKey(item.id ?? item.submission_id);
+        const nameKey = normSubmissionKey(item.name);
+        const rawColor =
+          item.submission_color ??
+          item.submissionColor ??
+          item.display_color ??
+          item.displayColor ??
+          item.color;
+        const css = sanitizeCssColor(rawColor);
+        if (!css) continue;
+        if (idKey) workshopSubmissionColorById.set(idKey, css);
+        if (nameKey) workshopSubmissionColorByName.set(nameKey, css);
+      }
+      workshopSubmissionColorsLoaded = true;
+    } catch {
+      // Keep empty maps on failure; layer tiles will still use direct metadata colors.
+    } finally {
+      workshopSubmissionColorsLoading = null;
+    }
+  })();
+  await workshopSubmissionColorsLoading;
+}
 
 function groupLayersByNameForSheet(layers, groupId) {
   const groups = new Map();
@@ -213,6 +262,85 @@ function layerIdsToPrimaryKey(fullLayerIds) {
   return JSON.stringify([...fullLayerIds].map(String).sort());
 }
 
+/**
+ * Decorative workshop tile swatch: first sanitized color on the row's layers.
+ * Tries explicit API fields, then registry/Leaflet-style hints, then nested metadata.
+ * If still missing, attempts lookup from submissions API cache (same source used by workshop page).
+ *
+ * @param {object} row
+ * @param {string} [groupId]
+ * @returns {string | null}
+ */
+function pickWorkshopRowSwatchCssColor(row, groupId) {
+  if (!row || !Array.isArray(row.layers)) return null;
+  const tryValue = (v) => {
+    const css = sanitizeCssColor(v);
+    return css || null;
+  };
+  for (const layer of row.layers) {
+    if (!layer || typeof layer !== "object") continue;
+    const direct =
+      layer.submissionColor ??
+      layer.displayColor ??
+      layer.submission_color ??
+      layer.display_color ??
+      layer.color ??
+      layer.fillColor ??
+      layer.strokeColor;
+    const fromDirect = tryValue(direct);
+    if (fromDirect) return fromDirect;
+
+    const style = layer.style;
+    if (style && typeof style === "object") {
+      for (const sk of ["fillColor", "color", "fill", "stroke"]) {
+        const v = style[sk];
+        if (typeof v !== "string") continue;
+        const css = tryValue(v);
+        if (css) return css;
+      }
+    }
+
+    const meta = layer.metadata;
+    if (meta && typeof meta === "object") {
+      for (const mk of [
+        "display_color",
+        "submissionColor",
+        "displayColor",
+        "color",
+        "primaryColor",
+      ]) {
+        const css = tryValue(meta[mk]);
+        if (css) return css;
+      }
+    }
+
+    const props = layer.properties;
+    if (props && typeof props === "object") {
+      const css = tryValue(props.display_color ?? props.displayColor);
+      if (css) return css;
+    }
+  }
+
+  const gid = String(groupId || "");
+  if (gid !== "curated_moresht_axis") return null;
+  for (const layer of row.layers) {
+    if (!layer || typeof layer !== "object") continue;
+    const idKey = normSubmissionKey(layer.submissionId ?? layer.submission_id ?? layer.id);
+    if (idKey && workshopSubmissionColorById.has(idKey)) {
+      return workshopSubmissionColorById.get(idKey) || null;
+    }
+    const nameCandidates = [layer.displayName, layer.name, row.displayLabel];
+    for (const candidate of nameCandidates) {
+      const nk = normSubmissionKey(candidate);
+      if (!nk) continue;
+      if (workshopSubmissionColorByName.has(nk)) {
+        return workshopSubmissionColorByName.get(nk) || null;
+      }
+    }
+  }
+  return null;
+}
+
 function renderLayerRow(row, options = {}) {
   const groupId = options.groupId || "";
   const checked =
@@ -266,15 +394,26 @@ function renderLayerRow(row, options = {}) {
         data-i18n-aria="ariaLayerAnimationToggle"
       >${playIcon}</button>`
     : "";
+  let workshopSwatch = "";
+  if (groupId === "curated_moresht_axis") {
+    const swatchCss = pickWorkshopRowSwatchCssColor(row, groupId);
+    if (swatchCss) {
+      workshopSwatch = buildCurationColorSwatchHtml(
+        swatchCss,
+        "layer-tile__swatch curation-published-layer-swatch",
+      );
+    }
+  }
   return `
     <div
       class="layer-tile ${stateClass}${visibleClass}${primaryClass}${animTileClass}"
+      role="button"
       tabindex="0"
       aria-pressed="${checked ? "true" : "false"}"
       aria-label="${escapeHtmlSafe(label)}"
       data-layer-ids="${layerIdsAttr}"
     >
-      <span class="layer-tile__label">${escapeHtmlSafe(label)}</span>
+      ${workshopSwatch}<span class="layer-tile__label">${escapeHtmlSafe(label)}</span>
       ${animControl}
     </div>
   `;
@@ -316,6 +455,9 @@ class LayerSheetController {
     if (typeof layerRegistry !== "undefined") {
       await layerRegistry.init();
     }
+    void ensureWorkshopSubmissionColorsLoaded().then(() => {
+      this.render();
+    });
 
     this.setupEventListeners();
     this.render();

--- a/otef-interactive/frontend/src/remote/layer-sheet-controller.js
+++ b/otef-interactive/frontend/src/remote/layer-sheet-controller.js
@@ -1,14 +1,18 @@
 /**
- * Layer Sheet Controller
+ * Layer list controller (Layers tab)
  *
- * Manages the bottom sheet UI for layer group selection.
- * Handles touch gestures, group expand/collapse, and sync with OTEFDataContext.
+ * Overview: pack list with active counts, pack on/off, open/drill, pack-level Flow
+ * (when the pack has animatable layers) — separate from per-row animation chips.
+ * Focused: one pack with row toggles, pack controls, and row- / pack-level animation
+ * as in the previous sheet implementation. Syncs with OTEFDataContext.
  */
 
 import {
+  formatLayerLabelForDisplay,
   normalizeLayerBaseName,
   parseLayerNameWithGeometrySuffix,
 } from "../shared/layer-name-utils.js";
+import { LOCALE_EVENT, applyRemoteChromeI18n, formatActiveLayerCount, t } from "./remote-locale.js";
 
 function groupLayersByNameForSheet(layers, groupId) {
   const groups = new Map();
@@ -52,7 +56,6 @@ function groupLayersByNameForSheet(layers, groupId) {
     }
   }
 
-  // Merge standalones whose normalized baseName matches a group's baseName
   for (const row of result) {
     const baseName = row.baseName;
     for (let i = standalones.length - 1; i >= 0; i--) {
@@ -96,6 +99,19 @@ function getRowAnimatableFullLayerIds(row, groupId) {
     .map((layer) => `${groupId}.${layer.id}`);
 }
 
+/**
+ * @param {{ id?: string, name?: string }} group
+ * @returns {string}
+ */
+function layerGroupTitle(group) {
+  const id = group && group.id;
+  const name = group && group.name;
+  if (id === "curated" || name === "Curated") {
+    return t("curatedGroupLabel");
+  }
+  return name ?? String(id ?? "");
+}
+
 function escapeHtmlSafe(value) {
   if (typeof escapeHtml === "function") {
     return escapeHtml(value);
@@ -108,6 +124,10 @@ function escapeHtmlSafe(value) {
     .replace(/'/g, "&#39;");
 }
 
+function encAttrId(id) {
+  return encodeURIComponent(String(id));
+}
+
 function renderLayerRow(row, options = {}) {
   const groupId = options.groupId || "";
   const checked =
@@ -116,8 +136,9 @@ function renderLayerRow(row, options = {}) {
     /"/g,
     "&quot;",
   );
-  const label =
+  const rawLabel =
     row.displayLabel ?? row.baseName ?? row.layers[0]?.name ?? row.layers[0]?.id ?? "";
+  const label = formatLayerLabelForDisplay(rawLabel);
   const preview = options.stylePreview || {
     fillColor: "#808080",
     fillOpacity: 0.7,
@@ -156,7 +177,7 @@ function renderLayerRow(row, options = {}) {
               class="animation-chip ${animationEnabled ? "active" : ""} ${animationMixed ? "mixed" : ""}"
               data-animation-toggle
               data-animation-layer-ids="${animIdsAttr}"
-            >Flow</button>`
+            >${escapeHtmlSafe(t("flowLabel"))}</button>`
           : ""
       }
     </div>
@@ -164,15 +185,16 @@ function renderLayerRow(row, options = {}) {
 }
 
 class LayerSheetController {
-  constructor() {
+  /**
+   * @param {{ rootId?: string }} [options]
+   */
+  constructor(options = {}) {
+    this.rootId = options.rootId || "layerSheet";
     this.sheet = null;
     this.isOpen = false;
-    this.startY = 0;
-    this.currentY = 0;
-    this.isDragging = false;
-    this.expandedGroups = new Set(); // Track which groups are expanded
+    /** @type {string | null} */
+    this.focusedGroupId = null;
 
-    // Initialize when DOM is ready
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", () => {
         this.init().catch((err) => {
@@ -187,13 +209,12 @@ class LayerSheetController {
   }
 
   async init() {
-    this.sheet = document.getElementById("layerSheet");
+    this.sheet = document.getElementById(this.rootId);
     if (!this.sheet) {
-      console.warn("[LayerSheetController] Layer sheet element not found");
+      console.warn("[LayerSheetController] Layer panel element not found");
       return;
     }
 
-    // Initialize layer registry if available
     if (typeof layerRegistry !== "undefined") {
       await layerRegistry.init();
     }
@@ -201,84 +222,43 @@ class LayerSheetController {
     this.setupEventListeners();
     this.render();
 
-    // Subscribe to layer group changes
     if (typeof OTEFDataContext !== "undefined") {
       OTEFDataContext.subscribe("layerGroups", () => this.render());
       OTEFDataContext.subscribe("animations", () => this.render());
     }
+
+    if (typeof window !== "undefined") {
+      window.addEventListener(LOCALE_EVENT, () => this.render());
+    }
   }
 
   setupEventListeners() {
-    const handle = this.sheet.querySelector(".sheet-handle");
+    const back = document.getElementById("layerPanelBack");
+    if (back) {
+      back.addEventListener("click", (e) => {
+        e.preventDefault();
+        this.clearLayerFocus();
+      });
+    }
+
     const content = this.sheet.querySelector(".sheet-content");
+    if (!content) return;
 
-    if (!handle || !content) return;
-
-    // Touch start
-    handle.addEventListener(
-      "touchstart",
-      (e) => {
-        this.startY = e.touches[0].clientY;
-        this.isDragging = true;
-        this.sheet.style.transition = "none";
-      },
-      { passive: true },
-    );
-
-    // Touch move
-    handle.addEventListener(
-      "touchmove",
-      (e) => {
-        if (!this.isDragging) return;
-        this.currentY = e.touches[0].clientY;
-        const deltaY = this.currentY - this.startY;
-
-        if (deltaY > 0) {
-          // Dragging down - closing
-          this.sheet.style.transform = `translateY(${deltaY}px)`;
-        }
-      },
-      { passive: true },
-    );
-
-    // Touch end
-    handle.addEventListener(
-      "touchend",
-      () => {
-        if (!this.isDragging) return;
-        this.isDragging = false;
-        this.sheet.style.transition = "transform 0.3s ease-out";
-
-        const deltaY = this.currentY - this.startY;
-        if (deltaY > 100) {
-          // Close if dragged down more than 100px
-          this.close();
-        } else {
-          // Snap back
-          this.sheet.style.transform = "";
-        }
-      },
-      { passive: true },
-    );
-
-    // Click handle to toggle
-    handle.addEventListener("click", () => {
-      if (this.isOpen) {
-        this.close();
-      } else {
-        this.open();
-      }
-    });
-
-    // Click outside to close
-    this.sheet.addEventListener("click", (e) => {
-      if (e.target === this.sheet) {
-        this.close();
-      }
-    });
-
-    // Delegated animation chip click handling (more reliable than inline handlers on mobile)
     content.addEventListener("click", (e) => {
+      const openBtn = e.target.closest("[data-layers-open-pack]");
+      if (openBtn) {
+        e.preventDefault();
+        e.stopPropagation();
+        const enc = openBtn.getAttribute("data-layers-open-pack");
+        if (!enc) return;
+        try {
+          this.focusOnGroup(decodeURIComponent(enc));
+        } catch {
+          // ignore malformed
+        }
+        return;
+      }
+
       const chip = e.target.closest("[data-animation-toggle]");
       if (!chip) return;
       e.preventDefault();
@@ -286,32 +266,56 @@ class LayerSheetController {
       let ids = [];
       try {
         ids = JSON.parse(chip.getAttribute("data-animation-layer-ids") || "[]");
-      } catch (_) {
+      } catch {
         ids = [];
       }
       if (!Array.isArray(ids) || ids.length === 0) return;
       const nextEnabled = !chip.classList.contains("active");
       this.toggleLayerRowAnimations(ids, nextEnabled);
     });
+
+    content.addEventListener("change", (e) => {
+      const t = e.target;
+      if (!(t instanceof HTMLInputElement)) return;
+      if (t.matches("input[data-layers-group-toggle]")) {
+        e.stopPropagation();
+        const enc = t.getAttribute("data-layers-enc-gid");
+        if (enc == null) return;
+        let gid = "";
+        try {
+          gid = decodeURIComponent(enc);
+        } catch {
+          return;
+        }
+        this.toggleGroupEnabled(gid, t.checked);
+      }
+    });
+  }
+
+  /**
+   * Leaving Layers tab: mark sheet not open. Drill-down (`focusedGroupId`) is kept
+   * so returning to Layers restores the same pack view; use Back in-panel for overview.
+   */
+  onLayersTabHidden() {
+    this.isOpen = false;
   }
 
   open() {
     this.isOpen = true;
-    this.sheet.classList.add("open");
     this.render();
   }
 
   close() {
     this.isOpen = false;
-    this.sheet.classList.remove("open");
   }
 
-  toggleGroup(groupId) {
-    if (this.expandedGroups.has(groupId)) {
-      this.expandedGroups.delete(groupId);
-    } else {
-      this.expandedGroups.add(groupId);
-    }
+  focusOnGroup(groupId) {
+    this.focusedGroupId = String(groupId);
+    this.render();
+  }
+
+  clearLayerFocus() {
+    this.focusedGroupId = null;
     this.render();
   }
 
@@ -377,10 +381,10 @@ class LayerSheetController {
     }
   }
 
-  render() {
-    const content = this.sheet.querySelector(".sheet-content");
-    if (!content) return;
-
+  /**
+   * @returns {Array}
+   */
+  getEffectiveGroupsForView() {
     let groups = [];
     if (
       typeof LayerStateHelper !== "undefined" &&
@@ -428,10 +432,10 @@ class LayerSheetController {
                   typeof cg.name === "string" &&
                   cg.name.trim() !== "") ||
                 (cg.id === "curated"
-                  ? "Curated"
+                  ? t("curatedGroupLabel")
                   : typeof cg.id === "string" && cg.id.startsWith("curated_")
                     ? cg.id.slice("curated_".length).replace(/_/g, " ").trim() ||
-                      "Curated"
+                      t("curatedGroupLabel")
                     : cg.id),
               enabled: cg.enabled,
               layers: (cg.layers || []).map((l) => ({
@@ -444,110 +448,36 @@ class LayerSheetController {
         }
       }
     }
+    return groups;
+  }
 
-    // Update layer count
-    const layerCountEl = this.sheet.querySelector(".layer-count");
-    if (layerCountEl) {
-      const totalEnabled = groups.reduce((sum, group) => {
-        return sum + (group.layers || []).filter((l) => l.enabled).length;
-      }, 0);
-      layerCountEl.textContent = `${totalEnabled} active`;
-    }
-
-    // Render groups
-    if (groups.length === 0) {
-      content.innerHTML =
-        '<div class="sheet-empty">No layer groups available</div>';
-      return;
-    }
-
-    const animations =
-      typeof OTEFDataContext !== "undefined" &&
-      typeof OTEFDataContext.getAnimations === "function"
-        ? OTEFDataContext.getAnimations() || {}
-        : {};
-
-    content.innerHTML = groups
-      .map((group) => {
-        const isExpanded = this.expandedGroups.has(group.id);
-        const enabledLayers = (group.layers || []).filter(
-          (l) => l.enabled,
-        ).length;
-        const totalLayers = (group.layers || []).length;
-        const packAnimatableLayerIds = (group.layers || [])
-          .filter((layer) => isLayerAnimatable(layer, group.id))
-          .map((layer) => `${group.id}.${layer.id}`);
-        const packHasAnimatable = packAnimatableLayerIds.length > 0;
-        const enabledPackAnimations = packHasAnimatable
-          ? packAnimatableLayerIds.filter((id) => !!animations[id]).length
-          : 0;
-        const packAnimationEnabled =
-          packHasAnimatable && enabledPackAnimations > 0;
-        const packAnimationMixed =
-          packHasAnimatable &&
-          enabledPackAnimations > 0 &&
-          enabledPackAnimations < packAnimatableLayerIds.length;
-        const packAnimLayerIdsAttr = JSON.stringify(packAnimatableLayerIds).replace(
-          /"/g,
-          "&quot;",
-        );
-
-        return `
-        <div class="layer-group" data-group-id="${group.id}">
-          <div class="group-header">
-            <div class="group-title-row" onclick="layerSheetController.toggleGroup('${group.id}')">
-              <span class="group-title">${escapeHtmlSafe(group.name)}</span>
-              <span class="group-count">${enabledLayers}/${totalLayers}</span>
-            </div>
-            <div class="group-controls">
-              ${
-                packHasAnimatable
-                  ? `<button
-                      type="button"
-                      class="animation-chip ${packAnimationEnabled ? "active" : ""} ${packAnimationMixed ? "mixed" : ""}"
-                      data-animation-toggle
-                      data-animation-layer-ids="${packAnimLayerIdsAttr}"
-                    >Flow</button>`
-                  : ""
-              }
-              <label class="group-toggle" onclick="event.stopPropagation()">
-                <input
-                  type="checkbox"
-                  ${group.enabled ? "checked" : ""}
-                  onchange="layerSheetController.toggleGroupEnabled('${group.id}', this.checked); event.stopPropagation();"
-                />
-                <span class="toggle-indicator"></span>
-              </label>
-              <svg class="expand-icon ${isExpanded ? "expanded" : ""}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" onclick="layerSheetController.toggleGroup('${group.id}')">
-                <polyline points="6 9 12 15 18 9"></polyline>
-              </svg>
-            </div>
-          </div>
-          <div class="group-layers ${isExpanded ? "expanded" : ""}">
-            ${(group.id === "october_7th" || group.id === "curated_moresht_axis"
-              ? groupLayersByNameForSheet(group.layers, group.id)
-              : (group.layers || []).map((layer) => ({
-                  baseName: layer.name || layer.id,
-                  fullLayerIds:
-                    Array.isArray(layer.fullLayerIds) && layer.fullLayerIds.length > 0
-                      ? layer.fullLayerIds
-                      : [`${group.id}.${layer.id}`],
-                  layers: [layer],
-                  enabled: layer.enabled,
-                }))
-            )
-              .map((row) => {
-                const style = this.getLayerStylePreview(row.layers[0]);
-                return renderLayerRow(row, {
-                  groupId: group.id,
-                  stylePreview: style,
-                  animations,
-                });
-              })
-              .join("")}
-          </div>
-        </div>
-      `;
+  /**
+   * @param {object} group
+   * @param {Record<string, boolean>} [animations]
+   * @returns {string}
+   */
+  buildLayerRowsHtml(group, animations) {
+    const anims = animations || {};
+    const rows =
+      group.id === "october_7th" || group.id === "curated_moresht_axis"
+        ? groupLayersByNameForSheet(group.layers, group.id)
+        : (group.layers || []).map((layer) => ({
+            baseName: layer.name || layer.id,
+            fullLayerIds:
+              Array.isArray(layer.fullLayerIds) && layer.fullLayerIds.length > 0
+                ? layer.fullLayerIds
+                : [`${group.id}.${layer.id}`],
+            layers: [layer],
+            enabled: layer.enabled,
+          }));
+    return rows
+      .map((row) => {
+        const style = this.getLayerStylePreview(row.layers[0]);
+        return renderLayerRow(row, {
+          groupId: group.id,
+          stylePreview: style,
+          animations: anims,
+        });
       })
       .join("");
   }
@@ -560,7 +490,6 @@ class LayerSheetController {
         strokeColor: "#000000",
       };
     }
-    // Handle image layers with a special preview style
     if (layer.format === "image" || layer.geometryType === "image") {
       return {
         fillColor: "#4a90e2",
@@ -576,7 +505,190 @@ class LayerSheetController {
     };
   }
 
-  // escapeHtml is provided by html-utils.js (loaded via script tag)
+  /**
+   * @param {object} group
+   * @param {Record<string, boolean>} animations
+   * @returns {string}
+   */
+  renderPackOverviewCard(group, animations) {
+    const enabledLayers = (group.layers || []).filter((l) => l.enabled).length;
+    const totalLayers = (group.layers || []).length;
+    const packAnimatableLayerIds = (group.layers || [])
+      .filter((layer) => isLayerAnimatable(layer, group.id))
+      .map((layer) => `${group.id}.${layer.id}`);
+    const packHasAnimatable = packAnimatableLayerIds.length > 0;
+    const enabledPackAnimations = packHasAnimatable
+      ? packAnimatableLayerIds.filter((id) => !!animations[id]).length
+      : 0;
+    const packAnimationEnabled = packHasAnimatable && enabledPackAnimations > 0;
+    const packAnimationMixed =
+      packHasAnimatable &&
+      enabledPackAnimations > 0 &&
+      enabledPackAnimations < packAnimatableLayerIds.length;
+    const packAnimLayerIdsAttr = JSON.stringify(packAnimatableLayerIds).replace(
+      /"/g,
+      "&quot;",
+    );
+    const enc = encAttrId(group.id);
+    return `
+    <div class="layer-pack-card" data-group-id="${enc}">
+      <div class="layer-pack-card__top">
+        <span class="layer-pack-card__title">${escapeHtmlSafe(layerGroupTitle(group))}</span>
+        <span class="group-count" aria-hidden="true">${enabledLayers}/${totalLayers}</span>
+      </div>
+      <div class="layer-pack-card__actions">
+        ${
+          packHasAnimatable
+            ? `<button
+                type="button"
+                class="animation-chip ${packAnimationEnabled ? "active" : ""} ${packAnimationMixed ? "mixed" : ""}"
+                data-animation-toggle
+                data-animation-layer-ids="${packAnimLayerIdsAttr}"
+              >${escapeHtmlSafe(t("flowLabel"))}</button>`
+            : ""
+        }
+        <label class="group-toggle" onclick="event.stopPropagation()">
+          <input
+            type="checkbox"
+            data-layers-group-toggle
+            data-layers-enc-gid="${enc}"
+            ${group.enabled ? "checked" : ""}
+          />
+          <span class="toggle-indicator"></span>
+        </label>
+        <button
+          type="button"
+          class="layer-pack-open"
+          data-layers-open-pack="${enc}"
+          data-i18n-aria="ariaLayersOpenPack"
+        >${escapeHtmlSafe(t("layersOpenPack"))}</button>
+      </div>
+    </div>`;
+  }
+
+  /**
+   * @param {object} group
+   * @param {Record<string, boolean>} animations
+   * @returns {string}
+   */
+  renderFocusedPack(group, animations) {
+    const enabledLayers = (group.layers || []).filter((l) => l.enabled).length;
+    const totalLayers = (group.layers || []).length;
+    const packAnimatableLayerIds = (group.layers || [])
+      .filter((layer) => isLayerAnimatable(layer, group.id))
+      .map((layer) => `${group.id}.${layer.id}`);
+    const packHasAnimatable = packAnimatableLayerIds.length > 0;
+    const enabledPackAnimations = packHasAnimatable
+      ? packAnimatableLayerIds.filter((id) => !!animations[id]).length
+      : 0;
+    const packAnimationEnabled = packHasAnimatable && enabledPackAnimations > 0;
+    const packAnimationMixed =
+      packHasAnimatable &&
+      enabledPackAnimations > 0 &&
+      enabledPackAnimations < packAnimatableLayerIds.length;
+    const packAnimLayerIdsAttr = JSON.stringify(packAnimatableLayerIds).replace(
+      /"/g,
+      "&quot;",
+    );
+
+    return `
+    <div class="layer-group layer-group--focus" data-group-id="${encAttrId(group.id)}">
+      <div class="group-header group-header--focus">
+        <div class="group-title-row">
+          <span class="group-title">${escapeHtmlSafe(layerGroupTitle(group))}</span>
+          <span class="group-count">${enabledLayers}/${totalLayers}</span>
+        </div>
+        <div class="group-controls">
+          ${
+            packHasAnimatable
+              ? `<button
+                  type="button"
+                  class="animation-chip ${packAnimationEnabled ? "active" : ""} ${packAnimationMixed ? "mixed" : ""}"
+                  data-animation-toggle
+                  data-animation-layer-ids="${packAnimLayerIdsAttr}"
+                >${escapeHtmlSafe(t("flowLabel"))}</button>`
+              : ""
+          }
+          <label class="group-toggle" onclick="event.stopPropagation()">
+            <input
+              type="checkbox"
+              data-layers-group-toggle
+              data-layers-enc-gid="${encAttrId(group.id)}"
+              ${group.enabled ? "checked" : ""}
+            />
+            <span class="toggle-indicator"></span>
+          </label>
+        </div>
+      </div>
+      <div class="group-layers group-layers--expanded">
+        ${this.buildLayerRowsHtml(group, animations)}
+      </div>
+    </div>
+  `;
+  }
+
+  updatePanelChrome(groups) {
+    const totalEnabled = groups.reduce((sum, group) => {
+      return sum + (group.layers || []).filter((l) => l.enabled).length;
+    }, 0);
+
+    const countEl = this.sheet.querySelector(".layer-count");
+    if (countEl) {
+      countEl.setAttribute("data-i18n-n", String(totalEnabled));
+      countEl.textContent = formatActiveLayerCount(totalEnabled);
+    }
+
+    const back = document.getElementById("layerPanelBack");
+    const titleEl = document.getElementById("layerPanelTitle");
+    if (this.focusedGroupId) {
+      if (back) back.hidden = false;
+      const fg = groups.find((g) => g.id === this.focusedGroupId);
+      if (titleEl && fg) {
+        titleEl.removeAttribute("data-i18n");
+        titleEl.textContent = layerGroupTitle(fg);
+      } else if (titleEl) {
+        titleEl.removeAttribute("data-i18n");
+        titleEl.textContent = t("layerSheetTitle");
+      }
+    } else {
+      if (back) back.hidden = true;
+      if (titleEl) {
+        titleEl.setAttribute("data-i18n", "layerSheetTitle");
+      }
+    }
+  }
+
+  render() {
+    const content = this.sheet && this.sheet.querySelector(".sheet-content");
+    if (!content) return;
+
+    const groups = this.getEffectiveGroupsForView();
+    this.updatePanelChrome(groups);
+
+    const animations =
+      typeof OTEFDataContext !== "undefined" &&
+      typeof OTEFDataContext.getAnimations === "function"
+        ? OTEFDataContext.getAnimations() || {}
+        : {};
+
+    if (this.focusedGroupId) {
+      const group = groups.find((g) => g.id === this.focusedGroupId);
+      if (!group) {
+        this.focusedGroupId = null;
+        this.render();
+        return;
+      }
+      content.innerHTML = this.renderFocusedPack(group, animations);
+    } else if (groups.length === 0) {
+      content.innerHTML = `<div class="sheet-empty">${escapeHtmlSafe(t("layerEmpty"))}</div>`;
+    } else {
+      const cards = groups
+        .map((g) => this.renderPackOverviewCard(g, animations))
+        .join("");
+      content.innerHTML = `<div class="layers-overview">${cards}</div>`;
+    }
+    applyRemoteChromeI18n();
+  }
 }
 
 let layerSheetController = null;

--- a/otef-interactive/frontend/src/remote/layer-sheet-controller.js
+++ b/otef-interactive/frontend/src/remote/layer-sheet-controller.js
@@ -1,10 +1,9 @@
 /**
  * Layer list controller (Layers tab)
  *
- * Overview: pack list with active counts, pack on/off, open/drill, pack-level Flow
- * (when the pack has animatable layers) — separate from per-row animation chips.
- * Focused: one pack with row toggles, pack controls, and row- / pack-level animation
- * as in the previous sheet implementation. Syncs with OTEFDataContext.
+ * **Sharpened Variant C:** pack chip strip (single selection) + per-pack count row +
+ * one bulk-visibility control for the selected pack + tile grid (per-layer on/off, animation
+ * icon button on tile only). Syncs with OTEFDataContext.
  */
 
 import {
@@ -12,7 +11,14 @@ import {
   normalizeLayerBaseName,
   parseLayerNameWithGeometrySuffix,
 } from "../shared/layer-name-utils.js";
-import { LOCALE_EVENT, applyRemoteChromeI18n, formatActiveLayerCount, t } from "./remote-locale.js";
+import {
+  LOCALE_EVENT,
+  applyRemoteChromeI18n,
+  formatActiveLayerCount,
+  getLocale,
+  t,
+} from "./remote-locale.js";
+import { getPackDisplayLabel } from "./layer-pack-display-names.js";
 
 function groupLayersByNameForSheet(layers, groupId) {
   const groups = new Map();
@@ -106,6 +112,12 @@ function getRowAnimatableFullLayerIds(row, groupId) {
 function layerGroupTitle(group) {
   const id = group && group.id;
   const name = group && group.name;
+  if (id) {
+    const packLabel = getPackDisplayLabel(String(id), getLocale());
+    if (typeof packLabel === "string" && packLabel.trim() !== "") {
+      return packLabel;
+    }
+  }
   if (id === "curated" || name === "Curated") {
     return t("curatedGroupLabel");
   }
@@ -128,6 +140,24 @@ function encAttrId(id) {
   return encodeURIComponent(String(id));
 }
 
+/** @param {string} value @param {string} fallback */
+function clampPreviewColor(value, fallback = "#808080") {
+  if (typeof value !== "string" || !/^#[0-9a-fA-F]{6}$/.test(value.trim())) {
+    return fallback;
+  }
+  return value.trim();
+}
+
+/**
+ * Stable key for comparing tile identity (order-independent).
+ * @param {string[] | undefined} fullLayerIds
+ * @returns {string | null}
+ */
+function layerIdsToPrimaryKey(fullLayerIds) {
+  if (!Array.isArray(fullLayerIds) || fullLayerIds.length === 0) return null;
+  return JSON.stringify([...fullLayerIds].map(String).sort());
+}
+
 function renderLayerRow(row, options = {}) {
   const groupId = options.groupId || "";
   const checked =
@@ -139,10 +169,15 @@ function renderLayerRow(row, options = {}) {
   const rawLabel =
     row.displayLabel ?? row.baseName ?? row.layers[0]?.name ?? row.layers[0]?.id ?? "";
   const label = formatLayerLabelForDisplay(rawLabel);
-  const preview = options.stylePreview || {
+  const previewRaw = options.stylePreview || {
     fillColor: "#808080",
     fillOpacity: 0.7,
     strokeColor: "#000000",
+  };
+  const preview = {
+    ...previewRaw,
+    fillColor: clampPreviewColor(previewRaw.fillColor),
+    strokeColor: clampPreviewColor(previewRaw.strokeColor),
   };
   const animatableIds = getRowAnimatableFullLayerIds(row, groupId);
   const hasAnimationToggle = animatableIds.length > 0;
@@ -157,29 +192,39 @@ function renderLayerRow(row, options = {}) {
     enabledAnimationCount > 0 &&
     enabledAnimationCount < animatableIds.length;
 
+  const stateClass = checked ? "is-on" : "is-off";
+  const rowKey = layerIdsToPrimaryKey(row.fullLayerIds);
+  const isPrimary =
+    checked &&
+    options.primaryTileIdsJson != null &&
+    rowKey === options.primaryTileIdsJson;
+  const primaryClass = isPrimary ? " layer-tile--primary" : "";
+  const visibleClass =
+    checked && !isPrimary ? " is-visible" : "";
+  const animStateClass = `${animationEnabled ? "active" : ""} ${
+    animationMixed ? "mixed" : ""
+  }`.trim();
+  const playIcon = `<svg class="anim-btn__glyph" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="M8 5v14l11-7z"/></svg>`;
+  const animControl = hasAnimationToggle
+    ? `<button
+        type="button"
+        class="anim-btn ${animStateClass}"
+        data-animation-toggle
+        data-animation-layer-ids="${animIdsAttr}"
+        data-i18n-aria="ariaLayerAnimationToggle"
+      >${playIcon}</button>`
+    : `<span class="anim-btn anim-btn--absent" aria-hidden="true"></span>`;
   return `
-    <div class="layer-item">
-      <div class="layer-preview" style="background-color: ${preview.fillColor}; opacity: ${preview.fillOpacity}; border-color: ${preview.strokeColor};"></div>
-      <label class="group-toggle" onclick="event.stopPropagation()">
-        <input
-          type="checkbox"
-          data-layer-ids="${layerIdsAttr}"
-          ${checked ? "checked" : ""}
-          onchange="layerSheetController.toggleLayerRow(JSON.parse(this.getAttribute('data-layer-ids')), this.checked); event.stopPropagation();"
-        />
-        <span class="toggle-indicator"></span>
-      </label>
-      <span class="layer-label">${escapeHtmlSafe(label)}</span>
-      ${
-        hasAnimationToggle
-          ? `<button
-              type="button"
-              class="animation-chip ${animationEnabled ? "active" : ""} ${animationMixed ? "mixed" : ""}"
-              data-animation-toggle
-              data-animation-layer-ids="${animIdsAttr}"
-            >${escapeHtmlSafe(t("flowLabel"))}</button>`
-          : ""
-      }
+    <div
+      class="layer-tile ${stateClass}${visibleClass}${primaryClass}"
+      tabindex="0"
+      aria-pressed="${checked ? "true" : "false"}"
+      aria-label="${escapeHtmlSafe(label)}"
+      data-layer-ids="${layerIdsAttr}"
+    >
+      <div class="layer-tile__preview" style="background-color: ${preview.fillColor}; opacity: ${preview.fillOpacity}; border-color: ${preview.strokeColor};"></div>
+      <span class="layer-tile__label">${escapeHtmlSafe(label)}</span>
+      ${animControl}
     </div>
   `;
 }
@@ -194,6 +239,8 @@ class LayerSheetController {
     this.isOpen = false;
     /** @type {string | null} */
     this.focusedGroupId = null;
+    /** @type {string | null} last-focused tile in focused pack (sorted `fullLayerIds` JSON) */
+    this.primaryTileIdsJson = null;
 
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", () => {
@@ -235,6 +282,7 @@ class LayerSheetController {
   setupEventListeners() {
     const back = document.getElementById("layerPanelBack");
     if (back) {
+      // Clears primary-tile emphasis only; selected pack stays (see `clearLayerFocus`).
       back.addEventListener("click", (e) => {
         e.preventDefault();
         this.clearLayerFocus();
@@ -244,12 +292,21 @@ class LayerSheetController {
     const content = this.sheet.querySelector(".sheet-content");
     if (!content) return;
 
+    content.addEventListener("keydown", (e) => {
+      if (e.key !== "Enter" && e.key !== " ") return;
+      if (!(e.target instanceof Element) || !e.target.matches(".layer-tile")) {
+        return;
+      }
+      e.preventDefault();
+      void this.runLayerTileToggleFromElement(e.target);
+    });
+
     content.addEventListener("click", (e) => {
-      const openBtn = e.target.closest("[data-layers-open-pack]");
-      if (openBtn) {
+      const selectPack = e.target.closest("[data-layers-select-pack]");
+      if (selectPack) {
         e.preventDefault();
         e.stopPropagation();
-        const enc = openBtn.getAttribute("data-layers-open-pack");
+        const enc = selectPack.getAttribute("data-layers-select-pack");
         if (!enc) return;
         try {
           this.focusOnGroup(decodeURIComponent(enc));
@@ -259,25 +316,33 @@ class LayerSheetController {
         return;
       }
 
-      const chip = e.target.closest("[data-animation-toggle]");
-      if (!chip) return;
-      e.preventDefault();
-      e.stopPropagation();
-      let ids = [];
-      try {
-        ids = JSON.parse(chip.getAttribute("data-animation-layer-ids") || "[]");
-      } catch {
-        ids = [];
+      const animBtn = e.target.closest("[data-animation-toggle]");
+      if (animBtn) {
+        e.preventDefault();
+        e.stopPropagation();
+        let ids = [];
+        try {
+          ids = JSON.parse(animBtn.getAttribute("data-animation-layer-ids") || "[]");
+        } catch {
+          ids = [];
+        }
+        if (!Array.isArray(ids) || ids.length === 0) return;
+        const nextEnabled = !animBtn.classList.contains("active");
+        this.toggleLayerRowAnimations(ids, nextEnabled);
+        return;
       }
-      if (!Array.isArray(ids) || ids.length === 0) return;
-      const nextEnabled = !chip.classList.contains("active");
-      this.toggleLayerRowAnimations(ids, nextEnabled);
+
+      const layerTile = e.target.closest(".layer-tile");
+      if (layerTile) {
+        e.preventDefault();
+        void this.runLayerTileToggleFromElement(layerTile);
+      }
     });
 
     content.addEventListener("change", (e) => {
       const t = e.target;
       if (!(t instanceof HTMLInputElement)) return;
-      if (t.matches("input[data-layers-group-toggle]")) {
+      if (t.matches("input[data-layers-bulk-visibility]")) {
         e.stopPropagation();
         const enc = t.getAttribute("data-layers-enc-gid");
         if (enc == null) return;
@@ -293,8 +358,8 @@ class LayerSheetController {
   }
 
   /**
-   * Leaving Layers tab: mark sheet not open. Drill-down (`focusedGroupId`) is kept
-   * so returning to Layers restores the same pack view; use Back in-panel for overview.
+   * Leaving Layers tab: mark sheet not open. Selected pack (`focusedGroupId`) is kept
+   * so returning to Layers restores the same strip + grid state.
    */
   onLayersTabHidden() {
     this.isOpen = false;
@@ -310,12 +375,41 @@ class LayerSheetController {
   }
 
   focusOnGroup(groupId) {
+    this.primaryTileIdsJson = null;
     this.focusedGroupId = String(groupId);
     this.render();
   }
 
+  /**
+   * Drop primary-tile highlight (`primaryTileIdsJson`). Does not change the selected
+   * pack; `render()` keeps a valid pack via `resolveSelectedPackId`.
+   */
   clearLayerFocus() {
-    this.focusedGroupId = null;
+    this.primaryTileIdsJson = null;
+    this.render();
+  }
+
+  /**
+   * @param {Element} layerTile
+   */
+  async runLayerTileToggleFromElement(layerTile) {
+    const raw = layerTile.getAttribute("data-layer-ids") || "[]";
+    let fullLayerIds = [];
+    try {
+      fullLayerIds = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    if (!Array.isArray(fullLayerIds) || fullLayerIds.length === 0) return;
+    const isOn = layerTile.classList.contains("is-on");
+    const result = await this.toggleLayerRow(fullLayerIds, !isOn);
+    if (!result || !result.ok) return;
+    const key = layerIdsToPrimaryKey(fullLayerIds);
+    if (!isOn) {
+      this.primaryTileIdsJson = key;
+    } else if (this.primaryTileIdsJson === key) {
+      this.primaryTileIdsJson = null;
+    }
     this.render();
   }
 
@@ -360,18 +454,14 @@ class LayerSheetController {
     }
   }
 
-  async toggleLayer(layerId, enabled) {
-    if (typeof OTEFDataContext !== "undefined") {
-      await OTEFDataContext.toggleLayer(layerId, enabled);
-    }
-  }
-
   async toggleLayerRow(fullLayerIds, enabled) {
-    if (!Array.isArray(fullLayerIds)) return;
-    if (fullLayerIds.length === 0) return;
-    if (typeof OTEFDataContext !== "undefined") {
-      await OTEFDataContext.setLayersEnabled(fullLayerIds, enabled);
+    if (!Array.isArray(fullLayerIds) || fullLayerIds.length === 0) {
+      return { ok: false };
     }
+    if (typeof OTEFDataContext !== "undefined") {
+      return await OTEFDataContext.setLayersEnabled(fullLayerIds, enabled);
+    }
+    return { ok: false };
   }
 
   async toggleLayerRowAnimations(fullLayerIds, enabled) {
@@ -477,6 +567,7 @@ class LayerSheetController {
           groupId: group.id,
           stylePreview: style,
           animations: anims,
+          primaryTileIdsJson: this.primaryTileIdsJson,
         });
       })
       .join("");
@@ -506,122 +597,91 @@ class LayerSheetController {
   }
 
   /**
-   * @param {object} group
-   * @param {Record<string, boolean>} animations
-   * @returns {string}
+   * @param {Array} groups
+   * @returns {string | null}
    */
-  renderPackOverviewCard(group, animations) {
-    const enabledLayers = (group.layers || []).filter((l) => l.enabled).length;
-    const totalLayers = (group.layers || []).length;
-    const packAnimatableLayerIds = (group.layers || [])
-      .filter((layer) => isLayerAnimatable(layer, group.id))
-      .map((layer) => `${group.id}.${layer.id}`);
-    const packHasAnimatable = packAnimatableLayerIds.length > 0;
-    const enabledPackAnimations = packHasAnimatable
-      ? packAnimatableLayerIds.filter((id) => !!animations[id]).length
-      : 0;
-    const packAnimationEnabled = packHasAnimatable && enabledPackAnimations > 0;
-    const packAnimationMixed =
-      packHasAnimatable &&
-      enabledPackAnimations > 0 &&
-      enabledPackAnimations < packAnimatableLayerIds.length;
-    const packAnimLayerIdsAttr = JSON.stringify(packAnimatableLayerIds).replace(
-      /"/g,
-      "&quot;",
-    );
-    const enc = encAttrId(group.id);
-    return `
-    <div class="layer-pack-card" data-group-id="${enc}">
-      <div class="layer-pack-card__top">
-        <span class="layer-pack-card__title">${escapeHtmlSafe(layerGroupTitle(group))}</span>
-        <span class="group-count" aria-hidden="true">${enabledLayers}/${totalLayers}</span>
-      </div>
-      <div class="layer-pack-card__actions">
-        ${
-          packHasAnimatable
-            ? `<button
-                type="button"
-                class="animation-chip ${packAnimationEnabled ? "active" : ""} ${packAnimationMixed ? "mixed" : ""}"
-                data-animation-toggle
-                data-animation-layer-ids="${packAnimLayerIdsAttr}"
-              >${escapeHtmlSafe(t("flowLabel"))}</button>`
-            : ""
-        }
-        <label class="group-toggle" onclick="event.stopPropagation()">
-          <input
-            type="checkbox"
-            data-layers-group-toggle
-            data-layers-enc-gid="${enc}"
-            ${group.enabled ? "checked" : ""}
-          />
-          <span class="toggle-indicator"></span>
-        </label>
-        <button
-          type="button"
-          class="layer-pack-open"
-          data-layers-open-pack="${enc}"
-          data-i18n-aria="ariaLayersOpenPack"
-        >${escapeHtmlSafe(t("layersOpenPack"))}</button>
-      </div>
-    </div>`;
+  resolveSelectedPackId(groups) {
+    if (!groups || groups.length === 0) return null;
+    if (
+      this.focusedGroupId &&
+      groups.some((g) => g.id === this.focusedGroupId)
+    ) {
+      return this.focusedGroupId;
+    }
+    return String(groups[0].id);
   }
 
   /**
-   * @param {object} group
+   * @param {Array} groups
    * @param {Record<string, boolean>} animations
    * @returns {string}
    */
-  renderFocusedPack(group, animations) {
-    const enabledLayers = (group.layers || []).filter((l) => l.enabled).length;
-    const totalLayers = (group.layers || []).length;
-    const packAnimatableLayerIds = (group.layers || [])
-      .filter((layer) => isLayerAnimatable(layer, group.id))
-      .map((layer) => `${group.id}.${layer.id}`);
-    const packHasAnimatable = packAnimatableLayerIds.length > 0;
-    const enabledPackAnimations = packHasAnimatable
-      ? packAnimatableLayerIds.filter((id) => !!animations[id]).length
-      : 0;
-    const packAnimationEnabled = packHasAnimatable && enabledPackAnimations > 0;
-    const packAnimationMixed =
-      packHasAnimatable &&
-      enabledPackAnimations > 0 &&
-      enabledPackAnimations < packAnimatableLayerIds.length;
-    const packAnimLayerIdsAttr = JSON.stringify(packAnimatableLayerIds).replace(
-      /"/g,
-      "&quot;",
-    );
+  renderLayersTabContent(groups, animations) {
+    const selectedId = this.focusedGroupId;
+    const selected = groups.find((g) => g.id === selectedId);
+    if (!selected) {
+      return `<div class="sheet-empty">${escapeHtmlSafe(t("layerEmpty"))}</div>`;
+    }
+    const enabledLayers = (selected.layers || []).filter((l) => l.enabled).length;
+    const totalLayers = (selected.layers || []).length;
+    const encGid = encAttrId(selected.id);
+    const packCountText = t("layersPackActiveCount", {
+      e: enabledLayers,
+      t: totalLayers,
+    });
+
+    const chips = groups
+      .map((g) => {
+        const enc = encAttrId(g.id);
+        const isSel = g.id === selectedId;
+        const currentAttr = isSel ? ' aria-current="true"' : "";
+        return `<button
+          type="button"
+          class="pack-chip${isSel ? " pack-chip--selected" : ""}"
+          data-layers-select-pack="${enc}"${currentAttr}
+        >${escapeHtmlSafe(layerGroupTitle(g))}</button>`;
+      })
+      .join("");
 
     return `
-    <div class="layer-group layer-group--focus" data-group-id="${encAttrId(group.id)}">
-      <div class="group-header group-header--focus">
-        <div class="group-title-row">
-          <span class="group-title">${escapeHtmlSafe(layerGroupTitle(group))}</span>
-          <span class="group-count">${enabledLayers}/${totalLayers}</span>
+    <div class="layers-variant-c">
+      <div
+        class="layers-pack-strip-wrap"
+        role="region"
+        data-i18n-aria="ariaLayersPackStrip"
+      >
+        <div class="layers-pack-head">
+          <p class="layers-pack-head__label" data-i18n="layersPackStripLabel">${escapeHtmlSafe(t("layersPackStripLabel"))}</p>
+          <span class="group-count" aria-hidden="true">${escapeHtmlSafe(packCountText)}</span>
         </div>
-        <div class="group-controls">
-          ${
-            packHasAnimatable
-              ? `<button
-                  type="button"
-                  class="animation-chip ${packAnimationEnabled ? "active" : ""} ${packAnimationMixed ? "mixed" : ""}"
-                  data-animation-toggle
-                  data-animation-layer-ids="${packAnimLayerIdsAttr}"
-                >${escapeHtmlSafe(t("flowLabel"))}</button>`
-              : ""
-          }
-          <label class="group-toggle" onclick="event.stopPropagation()">
-            <input
-              type="checkbox"
-              data-layers-group-toggle
-              data-layers-enc-gid="${encAttrId(group.id)}"
-              ${group.enabled ? "checked" : ""}
-            />
-            <span class="toggle-indicator"></span>
-          </label>
+        <div class="layers-pack-strip">
+          <div class="layers-pack-strip__viewport">
+            <div class="layers-pack-strip__edge layers-pack-strip__edge--start" aria-hidden="true"></div>
+            <div class="layers-pack-strip__edge layers-pack-strip__edge--end" aria-hidden="true"></div>
+            <div class="layers-pack-strip__scroller">
+              ${chips}
+            </div>
+          </div>
         </div>
       </div>
-      <div class="group-layers group-layers--expanded">
-        ${this.buildLayerRowsHtml(group, animations)}
+      <p class="layers-pack-scroll-hint" data-i18n="layersPackScrollHint">${escapeHtmlSafe(t("layersPackScrollHint"))}</p>
+      <div class="focused-pack-toolbar">
+        <span class="focused-pack-toolbar__label" data-i18n="layersBulkVisibility">${escapeHtmlSafe(t("layersBulkVisibility"))}</span>
+        <label class="group-toggle layer-bulk-visibility">
+          <input
+            type="checkbox"
+            data-layers-bulk-visibility
+            data-layers-enc-gid="${encGid}"
+            data-i18n-aria="ariaLayersBulkVisibility"
+            ${selected.enabled ? "checked" : ""}
+          />
+          <span class="toggle-indicator"></span>
+        </label>
+      </div>
+      <div class="group-layers group-layers--expanded group-layers--tiles">
+        <div class="layer-tile-grid">
+        ${this.buildLayerRowsHtml(selected, animations)}
+        </div>
       </div>
     </div>
   `;
@@ -639,22 +699,10 @@ class LayerSheetController {
     }
 
     const back = document.getElementById("layerPanelBack");
+    if (back) back.hidden = true;
     const titleEl = document.getElementById("layerPanelTitle");
-    if (this.focusedGroupId) {
-      if (back) back.hidden = false;
-      const fg = groups.find((g) => g.id === this.focusedGroupId);
-      if (titleEl && fg) {
-        titleEl.removeAttribute("data-i18n");
-        titleEl.textContent = layerGroupTitle(fg);
-      } else if (titleEl) {
-        titleEl.removeAttribute("data-i18n");
-        titleEl.textContent = t("layerSheetTitle");
-      }
-    } else {
-      if (back) back.hidden = true;
-      if (titleEl) {
-        titleEl.setAttribute("data-i18n", "layerSheetTitle");
-      }
+    if (titleEl) {
+      titleEl.setAttribute("data-i18n", "layerSheetTitle");
     }
   }
 
@@ -663,6 +711,12 @@ class LayerSheetController {
     if (!content) return;
 
     const groups = this.getEffectiveGroupsForView();
+    if (groups.length === 0) {
+      this.focusedGroupId = null;
+    } else {
+      this.focusedGroupId = this.resolveSelectedPackId(groups);
+    }
+
     this.updatePanelChrome(groups);
 
     const animations =
@@ -671,21 +725,21 @@ class LayerSheetController {
         ? OTEFDataContext.getAnimations() || {}
         : {};
 
-    if (this.focusedGroupId) {
-      const group = groups.find((g) => g.id === this.focusedGroupId);
-      if (!group) {
-        this.focusedGroupId = null;
-        this.render();
-        return;
-      }
-      content.innerHTML = this.renderFocusedPack(group, animations);
-    } else if (groups.length === 0) {
+    if (groups.length === 0) {
       content.innerHTML = `<div class="sheet-empty">${escapeHtmlSafe(t("layerEmpty"))}</div>`;
     } else {
-      const cards = groups
-        .map((g) => this.renderPackOverviewCard(g, animations))
-        .join("");
-      content.innerHTML = `<div class="layers-overview">${cards}</div>`;
+      content.innerHTML = this.renderLayersTabContent(groups, animations);
+      const selectedId = this.focusedGroupId;
+      const selected = groups.find((g) => g.id === selectedId);
+      if (selected) {
+        const layers = selected.layers || [];
+        const anyOn = layers.some((l) => l.enabled);
+        const anyOff = layers.some((l) => !l.enabled);
+        const bulkInput = content.querySelector("input[data-layers-bulk-visibility]");
+        if (bulkInput instanceof HTMLInputElement) {
+          bulkInput.indeterminate = anyOn && anyOff;
+        }
+      }
     }
     applyRemoteChromeI18n();
   }

--- a/otef-interactive/frontend/src/remote/remote-control-refresh-invariants.js
+++ b/otef-interactive/frontend/src/remote/remote-control-refresh-invariants.js
@@ -1,0 +1,11 @@
+/**
+ * Full UI sync (viewport, connection, curated heartbeat) reapplies default styles on
+ * pan/zoom/layer controls. When the joystick is active, the dpad is transiently
+ * disabled — callers must re-apply that lock after any such refresh.
+ *
+ * @param {null | "dpad" | "joystick"} activeControl
+ * @returns {boolean}
+ */
+export function shouldReapplyDpadAfterFullControlRefresh(activeControl) {
+  return activeControl === "joystick";
+}

--- a/otef-interactive/frontend/src/remote/remote-controller.js
+++ b/otef-interactive/frontend/src/remote/remote-controller.js
@@ -4,6 +4,13 @@
 
 import { rotateViewerVectorToItm } from "../shared/orientation-transform.js";
 import { startCuratedSupabaseHeartbeat } from "../shared/curated-supabase-heartbeat.js";
+import {
+  LOCALE_EVENT,
+  getLocale,
+  setLocale,
+  t,
+} from "./remote-locale.js";
+import { shouldReapplyDpadAfterFullControlRefresh } from "./remote-control-refresh-invariants.js";
 
 // Current UI state (synced from API)
 let currentState = {
@@ -28,8 +35,21 @@ const ZOOM_THROTTLE_MS = 100;
 // Table name for this controller
 const TABLE_NAME = "otef";
 
+/** Bottom shell tabs: matches LTR bar order (Workshop | Layers | Nav); arrow key navigation. */
+const REMOTE_TAB_KEYS = ["curation", "layers", "navigation"];
+
+/*
+ * Legacy `#toggleModel` wiring was removed: that checkbox is not part of the remote shell
+ * (Layers are toggled in the Layers tab / layer sheet). If a model quick-toggle is added
+ * to remote-controller.html later, reintroduce a small initializer here — do not reference a
+ * missing id from init (dead listeners).
+ */
+
 // Store unsubscribe functions for cleanup
 let unsubscribeFunctions = [];
+
+/** Last connection cluster state for re-applying translated status after locale change */
+let lastConnectionUiStatus = "connecting";
 
 // Initialize on DOM ready
 if (typeof document !== "undefined") {
@@ -94,8 +114,9 @@ async function initialize() {
   // Initialize UI controls
   initializePanControls();
   initializeZoomControls();
-  initializeLayerControls();
   initializeJoystick();
+  initRemoteShellTabs();
+  initRemoteLocaleControls();
 
   // Initial UI render with whatever state DataContext has
   updateUI();
@@ -118,9 +139,117 @@ async function initialize() {
 }
 
 /**
+ * Tab shell: show one `data-remote-tab` panel, sync `role="tab"` (Task 4; locale in Task 5).
+ */
+function setRemoteTab(activeKey) {
+  if (!REMOTE_TAB_KEYS.includes(activeKey)) return;
+
+  const panels = document.querySelectorAll(".remote-tab-panel[data-remote-tab]");
+  panels.forEach((panel) => {
+    const key = panel.getAttribute("data-remote-tab");
+    const isActive = key === activeKey;
+    panel.hidden = !isActive;
+  });
+
+  const nav = document.getElementById("remoteBottomNav");
+  if (!nav) return;
+
+  nav.querySelectorAll('[role="tab"][data-remote-tab]').forEach((tab) => {
+    const key = tab.getAttribute("data-remote-tab");
+    const isActive = key === activeKey;
+    tab.setAttribute("aria-selected", isActive ? "true" : "false");
+    tab.classList.toggle("is-active", isActive);
+    tab.tabIndex = isActive ? 0 : -1;
+  });
+
+  if (activeKey !== "layers" && window.layerSheetController) {
+    const ctrl = window.layerSheetController;
+    // Preserves focused pack; see LayerSheetController.onLayersTabHidden.
+    if (typeof ctrl.onLayersTabHidden === "function") ctrl.onLayersTabHidden();
+  }
+
+  if (activeKey === "layers" && window.layerSheetController) {
+    const ctrl = window.layerSheetController;
+    if (typeof ctrl.open === "function") ctrl.open();
+  }
+}
+
+/**
+ * Hebrew / English toggle and `otef:locale` → connection line + toggle `aria-pressed`
+ */
+function initRemoteLocaleControls() {
+  const heBtn = document.getElementById("remoteLocaleHe");
+  const enBtn = document.getElementById("remoteLocaleEn");
+
+  const syncToggleFromLocale = () => {
+    const loc = getLocale();
+    if (heBtn) {
+      heBtn.classList.toggle("is-active", loc === "he");
+      heBtn.setAttribute("aria-pressed", loc === "he" ? "true" : "false");
+    }
+    if (enBtn) {
+      enBtn.classList.toggle("is-active", loc === "en");
+      enBtn.setAttribute("aria-pressed", loc === "en" ? "true" : "false");
+    }
+  };
+
+  syncToggleFromLocale();
+
+  if (heBtn) {
+    heBtn.addEventListener("click", () => setLocale("he"));
+  }
+  if (enBtn) {
+    enBtn.addEventListener("click", () => setLocale("en"));
+  }
+
+  if (typeof window !== "undefined") {
+    window.addEventListener(LOCALE_EVENT, () => {
+      syncToggleFromLocale();
+      updateConnectionStatus(lastConnectionUiStatus);
+    });
+  }
+
+  updateConnectionStatus(
+    currentState.isConnected ? "connected" : "disconnected",
+  );
+}
+
+function initRemoteShellTabs() {
+  const nav = document.getElementById("remoteBottomNav");
+  if (!nav) return;
+
+  nav.addEventListener("click", (e) => {
+    const tab = e.target.closest('[role="tab"][data-remote-tab]');
+    if (!tab || !nav.contains(tab)) return;
+    const k = tab.getAttribute("data-remote-tab");
+    if (k) setRemoteTab(k);
+  });
+
+  nav.addEventListener("keydown", (e) => {
+    const el = e.target;
+    if (!el || el.getAttribute("role") !== "tab" || !nav.contains(el)) return;
+    if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
+    e.preventDefault();
+    const key = el.getAttribute("data-remote-tab");
+    const i = REMOTE_TAB_KEYS.indexOf(key);
+    if (i < 0) return;
+    const delta = e.key === "ArrowRight" ? 1 : -1;
+    const next = (i + delta + REMOTE_TAB_KEYS.length) % REMOTE_TAB_KEYS.length;
+    const nextKey = REMOTE_TAB_KEYS[next];
+    setRemoteTab(nextKey);
+    document.getElementById(`remote-tab-${nextKey}`)?.focus();
+  });
+
+  // Single source of truth on load: panels + tablist aria (HTML may omit `hidden` on nav tab)
+  setRemoteTab("navigation");
+}
+
+/**
  * Update connection status UI
  */
 function updateConnectionStatus(status) {
+  lastConnectionUiStatus = status;
+
   const indicator = document.getElementById("statusIndicator");
   const text = document.getElementById("statusText");
   const warning = document.getElementById("warningOverlay");
@@ -128,25 +257,25 @@ function updateConnectionStatus(status) {
   if (!indicator || !text) return;
 
   const statusConfig = {
-    connected: { class: "connected", text: "Connected", showWarning: false },
+    connected: { class: "connected", textKey: "statusConnected", showWarning: false },
     disconnected: {
       class: "disconnected",
-      text: "Disconnected",
+      textKey: "statusDisconnected",
       showWarning: true,
     },
     connecting: {
       class: "connecting",
-      text: "Connecting...",
+      textKey: "statusConnecting",
       showWarning: false,
     },
-    error: { class: "disconnected", text: "Error", showWarning: true },
+    error: { class: "disconnected", textKey: "statusError", showWarning: true },
   };
 
   const config = statusConfig[status] || statusConfig.disconnected;
 
   indicator.classList.remove("connected", "disconnected", "connecting");
   indicator.classList.add(config.class);
-  text.textContent = config.text;
+  text.textContent = t(config.textKey);
 
   currentState.isConnected = status === "connected";
 
@@ -275,47 +404,6 @@ function updateZoomUI(zoom) {
   }
 }
 
-/** Full layer id for the single "model" toggle (projector base). */
-const MODEL_LAYER_FULL_ID = "projector_base.model_base";
-
-/**
- * Initialize layer controls (layerGroups only; model toggle uses full id).
- */
-function initializeLayerControls() {
-  const checkbox = document.getElementById("toggleModel");
-  if (!checkbox) return;
-
-  checkbox.addEventListener("change", async (e) => {
-    if (!currentState.isConnected) {
-      const state =
-        typeof LayerStateHelper !== "undefined"
-          ? LayerStateHelper.getLayerState(MODEL_LAYER_FULL_ID)
-          : null;
-      e.target.checked = state ? !!state.enabled : false;
-      return;
-    }
-
-    try {
-      const result = await OTEFDataContext.toggleLayer(
-        MODEL_LAYER_FULL_ID,
-        e.target.checked,
-      );
-      if (!result || !result.ok) {
-        throw result && result.error
-          ? result.error
-          : new Error("Layer update failed");
-      }
-    } catch (error) {
-      console.error("[Remote] Layer update failed:", error);
-      const state =
-        typeof LayerStateHelper !== "undefined"
-          ? LayerStateHelper.getLayerState(MODEL_LAYER_FULL_ID)
-          : null;
-      e.target.checked = state ? !!state.enabled : false;
-    }
-  });
-}
-
 /**
  * Initialize joystick control
  */
@@ -426,28 +514,12 @@ function enableDPad() {
   });
 }
 
-function updateLayerCheckboxes() {
-  const checkbox = document.getElementById("toggleModel");
-  if (!checkbox) return;
-  const state =
-    typeof LayerStateHelper !== "undefined"
-      ? LayerStateHelper.getLayerState(MODEL_LAYER_FULL_ID)
-      : null;
-  const enabled = state ? !!state.enabled : false;
-  if (checkbox.checked !== enabled) {
-    checkbox.checked = enabled;
-  }
-}
-
 /**
  * Update all UI elements based on current state
  */
 function updateUI() {
   // Update zoom
   updateZoomUI(currentState.viewport.zoom);
-
-  // Update layer checkboxes
-  updateLayerCheckboxes();
 
   // Disable controls if not connected
   const controls = document.querySelectorAll(
@@ -462,6 +534,13 @@ function updateUI() {
       control.style.pointerEvents = "none";
     }
   });
+
+  if (
+    currentState.isConnected &&
+    shouldReapplyDpadAfterFullControlRefresh(activeControl)
+  ) {
+    disableDPad();
+  }
 }
 
 // Cleanup on page unload

--- a/otef-interactive/frontend/src/remote/remote-locale.js
+++ b/otef-interactive/frontend/src/remote/remote-locale.js
@@ -35,8 +35,7 @@ const MESSAGES = {
     navLayers: "שכבות",
     navCuration: "סדנה",
     sectionNavigation: "ניווט",
-    navPanGroupLabel: "הזזה",
-    navZoomGroupLabel: "זום",
+    navPanGroupLabel: "",
     zoomLabel: "זום:",
     statusConnected: "מחובר",
     statusDisconnected: "מנותק",
@@ -58,10 +57,7 @@ const MESSAGES = {
     flowLabel: "זרימה",
     curatedGroupLabel: "אסופה",
     layersOpenPack: "הצג",
-    layersPackStripLabel: "חבילה",
-    layersPackActiveCount: "{{e}}/{{t}} פעילות",
-    layersPackScrollHint: "גלילה אופקית · Swipe horizontally",
-    ariaLayersPackStrip: "בחירת חבילת שכבות",
+    layersPackActiveCount: "{{e}}/{{t}}",
     ariaLayerAnimationToggle: "הפעלת או כיבוי אנימציית זרימה לשכבה",
     layersBulkVisibility: "כל השכבות בחבילה",
     ariaLayersBulkVisibility: "הפעלת או כיבוי כל השכבות בחבילה שנבחרה",
@@ -78,7 +74,7 @@ const MESSAGES = {
     curationHeaderRefreshAria: "רענון",
     curationDocumentTitle: "OTEF | אצירה",
     curationPublishHeading: "פרסום",
-    curationPublishButton: "פרסום כשכבת OTEF",
+    curationPublishButton: "פרסם שכבה",
     curationSelectSubmissionError: "בחרו הגשה לפרסום.",
     curationMissingGroupError: "חסר שם קבוצה לאסוף.",
     curationNoFeaturesError: "אין תצוגה נוכחית לפרסום עבור הגשה זו.",
@@ -97,7 +93,7 @@ const MESSAGES = {
     curationPublishedHeading: "שכבות מפורסמות בבקר",
     curationWorkshopAutoPublish: "פרסום אוטומטי לסדנה",
     curationWorkshopAutoPublishAria: "פרסום אוטומטי לסדנה",
-    curationUnpublishAll: "בטל את כל הפרסומים",
+    curationUnpublishAll: "הסר הכל",
     curationPublishedLoading: "טוען שכבות אצירה מפורסמות…",
     curationSubmissionSearchPlaceholder: "חיפוש או בחירת הגשה…",
     curationSubmissionSearchAria: "חיפוש ובחירת הגשה",
@@ -129,12 +125,11 @@ const MESSAGES = {
     documentTitle: "OTEF",
     localeGroupAria: "Language",
     navTablistAria: "Controller areas",
-    navNavigation: "Nav",
+    navNavigation: "Navigation",
     navLayers: "Layers",
     navCuration: "Workshop",
     sectionNavigation: "Navigation",
-    navPanGroupLabel: "Pan",
-    navZoomGroupLabel: "Zoom",
+    navPanGroupLabel: "",
     zoomLabel: "Zoom:",
     statusConnected: "Connected",
     statusDisconnected: "Disconnected",
@@ -156,10 +151,7 @@ const MESSAGES = {
     flowLabel: "Flow",
     curatedGroupLabel: "Curated",
     layersOpenPack: "View",
-    layersPackStripLabel: "Pack",
-    layersPackActiveCount: "{{e}}/{{t}} active",
-    layersPackScrollHint: "Swipe horizontally — more packs",
-    ariaLayersPackStrip: "Choose a layer pack",
+    layersPackActiveCount: "{{e}}/{{t}}",
     ariaLayerAnimationToggle: "Enable or disable flow animation for this layer",
     layersBulkVisibility: "All layers in pack",
     ariaLayersBulkVisibility: "Enable or disable every layer in the selected pack",
@@ -176,7 +168,7 @@ const MESSAGES = {
     curationHeaderRefreshAria: "Refresh",
     curationDocumentTitle: "OTEF | Curation",
     curationPublishHeading: "Publish",
-    curationPublishButton: "Publish as OTEF layer",
+    curationPublishButton: "Publish layer",
     curationSelectSubmissionError: "Select a submission to publish.",
     curationMissingGroupError: "Missing curated group name.",
     curationNoFeaturesError: "No current features to publish for this submission.",
@@ -315,6 +307,12 @@ export function applyRemoteChromeI18n() {
     const isCuration =
       typeof document.querySelector === "function" && document.querySelector(".curation-layout");
     document.title = isCuration ? t("curationDocumentTitle") : MESSAGES[_locale].documentTitle;
+  }
+  if (typeof document.getElementById === "function") {
+    const submissionSearch = document.getElementById("curationSubmissionSearch");
+    if (submissionSearch) {
+      submissionSearch.setAttribute("dir", _locale === "he" ? "rtl" : "ltr");
+    }
   }
 }
 

--- a/otef-interactive/frontend/src/remote/remote-locale.js
+++ b/otef-interactive/frontend/src/remote/remote-locale.js
@@ -1,0 +1,251 @@
+/**
+ * Remote controller UI locale: Hebrew default, English toggle, lang + dir on document root.
+ * Main content (`#remoteMain`) gets matching `dir` for readable flow; `body` for the remote shell
+ * is LTR in CSS (see remote-styles) so header/bottom nav do not mirror with document `dir`.
+ * WebSocket/API/layer ids are never translated here — only display copy.
+ *
+ * @see LOCALE_EVENT — fired after locale is applied; listeners re-render dynamic strings.
+ */
+
+export const LOCALE_STORAGE_KEY = "otef.remote.locale";
+export const LOCALE_EVENT = "otef:locale";
+
+const SUPPORTED = /** @type {const} */ (["he", "en"]);
+
+/**
+ * @typedef {"he" | "en"} LocaleId
+ */
+
+/** @type {LocaleId} */
+let _locale = "he";
+
+/**
+ * Not translated via MESSAGES: language autonyms on toggle ("עברית", "English");
+ * product token "OTEF" in page title; layer/group display names from API;
+ * `curatedGroupLabel` is the fallback title when the `curated` group has no API name
+ * (same English string as the former hard-coded fallback, localized for Hebrew).
+ */
+
+const MESSAGES = {
+  he: {
+    documentTitle: "OTEF",
+    localeGroupAria: "בחירת שפה",
+    navTablistAria: "אזורי בקרה",
+    navNavigation: "ניווט",
+    navLayers: "שכבות",
+    navCuration: "סדנה",
+    sectionNavigation: "ניווט",
+    zoomLabel: "זום:",
+    statusConnected: "מחובר",
+    statusDisconnected: "מנותק",
+    statusConnecting: "מתחבר…",
+    statusError: "שגיאה",
+    layerSheetTitle: "שכבות",
+    layersActiveCount: "{{n}} פעיל",
+    layerEmpty: "אין קבוצות שכבות",
+    curationIframeTitle: "סדנה — אצירה",
+    warningControlsDisabled: "המפה אינה מחוברת. הבקרות אינן פעילות.",
+    ariaPanNorth: "הזזה צפונה",
+    ariaPanSouth: "הזזה דרומה",
+    ariaPanEast: "הזזה מזרחה",
+    ariaPanWest: "הזזה מערבה",
+    joystickAria: "מוט כיוון לגרירת המפה",
+    ariaZoomLevel: "רמת מיקוד",
+    ariaZoomIn: "התקרבות",
+    ariaZoomOut: "התרחקות",
+    flowLabel: "זרימה",
+    curatedGroupLabel: "אסופה",
+    layersOpenPack: "הצג",
+    layersBack: "רשימת חבילות",
+    ariaLayersBack: "חזרה לרשימת חבילות",
+    ariaLayersOpenPack: "הצגת שכבות בחבילה",
+  },
+  en: {
+    documentTitle: "OTEF",
+    localeGroupAria: "Language",
+    navTablistAria: "Controller areas",
+    navNavigation: "Nav",
+    navLayers: "Layers",
+    navCuration: "Workshop",
+    sectionNavigation: "Navigation",
+    zoomLabel: "Zoom:",
+    statusConnected: "Connected",
+    statusDisconnected: "Disconnected",
+    statusConnecting: "Connecting…",
+    statusError: "Error",
+    layerSheetTitle: "Layers",
+    layersActiveCount: "{{n}} active",
+    layerEmpty: "No layer groups available",
+    curationIframeTitle: "Workshop — curation",
+    warningControlsDisabled: "GIS map not connected. Controls disabled.",
+    ariaPanNorth: "Pan North",
+    ariaPanSouth: "Pan South",
+    ariaPanEast: "Pan East",
+    ariaPanWest: "Pan West",
+    joystickAria: "Virtual joystick for map panning",
+    ariaZoomLevel: "Zoom level",
+    ariaZoomIn: "Zoom In",
+    ariaZoomOut: "Zoom Out",
+    flowLabel: "Flow",
+    curatedGroupLabel: "Curated",
+    layersOpenPack: "View",
+    layersBack: "All packs",
+    ariaLayersBack: "Back to all packs",
+    ariaLayersOpenPack: "View layers in this pack",
+  },
+};
+
+/**
+ * @param {string} key
+ * @returns {keyof (typeof MESSAGES)["he"]}
+ */
+function isMessageKey(key) {
+  return key in MESSAGES.he;
+}
+
+/**
+ * @param {string} [key]
+ * @returns {key is LocaleId}
+ */
+function isLocaleId(key) {
+  return key === "he" || key === "en";
+}
+
+function readStored() {
+  try {
+    const v = localStorage.getItem(LOCALE_STORAGE_KEY);
+    if (isLocaleId(v)) return v;
+  } catch {
+    // ignore
+  }
+  return "he";
+}
+
+function applyDocumentRoot() {
+  if (typeof document === "undefined") return;
+  const el = document.documentElement;
+  const dir = _locale === "he" ? "rtl" : "ltr";
+  el.setAttribute("lang", _locale === "he" ? "he" : "en");
+  el.setAttribute("dir", dir);
+  if (typeof document.getElementById === "function") {
+    const main = document.getElementById("remoteMain");
+    if (main) {
+      main.setAttribute("dir", dir);
+    }
+  }
+}
+
+/**
+ * Fills [data-i18n] with `MESSAGES[locale][key]`. Values support `{{n}}` replacement when passed as data-i18n-n (optional).
+ */
+export function applyRemoteChromeI18n() {
+  if (typeof document === "undefined") return;
+  if (typeof document.querySelectorAll !== "function") return;
+  const textNodes = document.querySelectorAll("[data-i18n]");
+  textNodes.forEach((el) => {
+    const key = el.getAttribute("data-i18n");
+    if (!key || !isMessageKey(key)) return;
+    const row = MESSAGES[_locale];
+    const template = row[key] ?? MESSAGES.en[key] ?? key;
+    let text = template;
+    const nAttr = el.getAttribute("data-i18n-n");
+    if (nAttr != null && nAttr !== "") {
+      text = text.replace(/\{\{n\}\}/g, nAttr);
+    } else {
+      text = text.replace(/\{\{n\}\}/g, "");
+    }
+    el.textContent = text;
+  });
+  const ariaNodes = document.querySelectorAll("[data-i18n-aria]");
+  ariaNodes.forEach((el) => {
+    const key = el.getAttribute("data-i18n-aria");
+    if (!key || !isMessageKey(key)) return;
+    el.setAttribute("aria-label", t(key));
+  });
+  document.querySelectorAll("[data-i18n-title]").forEach((el) => {
+    const key = el.getAttribute("data-i18n-title");
+    if (!key || !isMessageKey(key)) return;
+    el.setAttribute("title", t(key));
+  });
+  const title = MESSAGES[_locale].documentTitle;
+  if (typeof document.title === "string") {
+    document.title = title;
+  }
+}
+
+/**
+ * @returns {LocaleId}
+ */
+export function getLocale() {
+  return _locale;
+}
+
+/**
+ * @param {LocaleId} next
+ * @param {{ force?: boolean }} [opts]
+ * @returns {void}
+ */
+export function setLocale(next, opts = {}) {
+  if (!isLocaleId(next)) return;
+  if (!opts.force && _locale === next) return;
+
+  _locale = next;
+  try {
+    localStorage.setItem(LOCALE_STORAGE_KEY, _locale);
+  } catch {
+    // ignore
+  }
+  applyDocumentRoot();
+  applyRemoteChromeI18n();
+  if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+    window.dispatchEvent(
+      new CustomEvent(LOCALE_EVENT, { detail: { locale: _locale } }),
+    );
+  }
+}
+
+/**
+ * Read persisted locale, apply `lang` / `dir`, static chrome strings, and dispatch `LOCALE_EVENT`.
+ */
+export function initLocale() {
+  const stored = readStored();
+  if (stored === _locale) {
+    applyDocumentRoot();
+    applyRemoteChromeI18n();
+    if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {
+      window.dispatchEvent(
+        new CustomEvent(LOCALE_EVENT, { detail: { locale: _locale } }),
+      );
+    }
+  } else {
+    setLocale(stored, { force: true });
+  }
+}
+
+/**
+ * @param {string} key
+ * @param {{ n?: string | number }} [vars]
+ * @returns {string}
+ */
+export function t(key, vars = {}) {
+  if (!isMessageKey(key)) return String(key);
+  const k = key;
+  const row = MESSAGES[_locale];
+  let text = (row && row[k]) || MESSAGES.en[k] || key;
+  if (vars && vars.n != null) {
+    text = text.replace(/\{\{n\}\}/g, String(vars.n));
+  } else {
+    text = text.replace(/\{\{n\}\}/g, "");
+  }
+  return text;
+}
+
+/**
+ * @param {number} totalEnabled
+ * @returns {string}
+ */
+export function formatActiveLayerCount(totalEnabled) {
+  return t("layersActiveCount", { n: totalEnabled });
+}
+
+export { SUPPORTED as SUPPORTED_LOCALES };

--- a/otef-interactive/frontend/src/remote/remote-locale.js
+++ b/otef-interactive/frontend/src/remote/remote-locale.js
@@ -20,7 +20,7 @@ const SUPPORTED = /** @type {const} */ (["he", "en"]);
 let _locale = "he";
 
 /**
- * Not translated via MESSAGES: language autonyms on toggle ("עברית", "English");
+ * Not translated via MESSAGES: compact language labels on the toggle ("עב", "en" in markup);
  * product token "OTEF" in page title; layer/group display names from API;
  * `curatedGroupLabel` is the fallback title when the `curated` group has no API name
  * (same English string as the former hard-coded fallback, localized for Hebrew).
@@ -35,6 +35,8 @@ const MESSAGES = {
     navLayers: "שכבות",
     navCuration: "סדנה",
     sectionNavigation: "ניווט",
+    navPanGroupLabel: "הזזה",
+    navZoomGroupLabel: "זום",
     zoomLabel: "זום:",
     statusConnected: "מחובר",
     statusDisconnected: "מנותק",
@@ -56,9 +58,72 @@ const MESSAGES = {
     flowLabel: "זרימה",
     curatedGroupLabel: "אסופה",
     layersOpenPack: "הצג",
+    layersPackStripLabel: "חבילה",
+    layersPackActiveCount: "{{e}}/{{t}} פעילות",
+    layersPackScrollHint: "גלילה אופקית · Swipe horizontally",
+    ariaLayersPackStrip: "בחירת חבילת שכבות",
+    ariaLayerAnimationToggle: "הפעלת או כיבוי אנימציית זרימה לשכבה",
+    layersBulkVisibility: "כל השכבות בחבילה",
+    ariaLayersBulkVisibility: "הפעלת או כיבוי כל השכבות בחבילה שנבחרה",
     layersBack: "רשימת חבילות",
     ariaLayersBack: "חזרה לרשימת חבילות",
     ariaLayersOpenPack: "הצגת שכבות בחבילה",
+    curationSubmissionsRefreshTitle: "רענון רשימת הגשות",
+    curationSubmissionsRefreshAria: "רענון רשימת ההגשות",
+    curationSubmissionsHeading: "הגשות",
+    curationPageTitle: "אצירה",
+    curationBackLink: "בקר",
+    curationBackAria: "פתיחת בקר",
+    curationHeaderRefresh: "רענון",
+    curationHeaderRefreshAria: "רענון",
+    curationDocumentTitle: "OTEF | אצירה",
+    curationPublishHeading: "פרסום",
+    curationPublishButton: "פרסום כשכבת OTEF",
+    curationSelectSubmissionError: "בחרו הגשה לפרסום.",
+    curationMissingGroupError: "חסר שם קבוצה לאסוף.",
+    curationNoFeaturesError: "אין תצוגה נוכחית לפרסום עבור הגשה זו.",
+    curationPublishing: "מפרסמים…",
+    curationPublishedSuccess: "פורסם \"{{e}}\".",
+    curationPublishFailed: "הפרסום נכשל: {{e}}",
+    curationUnpublishAllConfirm: "להסיר את כל שכבות האצירה המפורסמות מהבקר המרוחק?",
+    curationUnpublishAllInProgress: "מסירים את כל שכבות האצירה המפורסמות…",
+    curationUnpublishAllRemovedN: "הוסרו {{n}} שכבה/ות מפורסמות.",
+    curationUnpublishAllSuccess: "הוסרו כל שכבות האצירה המפורסמות.",
+    curationUnpublishAllError: "לא ניתן לבטל את כל הפרסומים: {{e}}",
+    curationLoadWorkshopError: "לא ניתן לטעון מצב סדנה: {{e}}",
+    curationWorkshopOnSuccess: "פרסום אוטומטי לסדנה מופעל: הגשות חדשות עשויות להתפרסם אוטומטית.",
+    curationWorkshopOffSuccess: "פרסום אוטומטי לסדנה כבוי.",
+    curationUpdateWorkshopError: "לא ניתן לעדכן מצב סדנה: {{e}}",
+    curationPublishedHeading: "שכבות מפורסמות בבקר",
+    curationWorkshopAutoPublish: "פרסום אוטומטי לסדנה",
+    curationWorkshopAutoPublishAria: "פרסום אוטומטי לסדנה",
+    curationUnpublishAll: "בטל את כל הפרסומים",
+    curationPublishedLoading: "טוען שכבות אצירה מפורסמות…",
+    curationSubmissionSearchPlaceholder: "חיפוש או בחירת הגשה…",
+    curationSubmissionSearchAria: "חיפוש ובחירת הגשה",
+    curationSubmissionListAria: "הגשות",
+    curationSubmissionsEmpty: "לא נטענו הגשות.",
+    curationSubmissionsNoMatch: "אין תוצאות.",
+    curationSubmissionsLoading: "טוען הגשות…",
+    curationSubmissionsLoadError: "לא ניתן לטעון הגשות: {{e}}",
+    curationNoPublishedLayers: "אין שכבות אצירה מפורסמות.",
+    curationLoadingPublished: "טוען שכבות אצירה מפורסמות…",
+    curationLoadPublishedError: "לא ניתן לטעון שכבות אצירה: {{e}}",
+    curationTagTkumaLine: "קו תקומה",
+    curationTagMemorials: "הנצחה",
+    curationSubmissionColorTitle: "צבע הגשה",
+    curationOpenSubmissionForLayer: "פתח את ההגשה \"{{e}}\" עבור השכבה \"{{n}}\"",
+    curationOpenSubmissionUnnamed: "פתח את ההגשה עבור השכבה \"{{e}}\"",
+    curationPublishedLayerUnknown: "שכבה \"{{e}}\": הגשה לא ידועה (מרובות או חסרה); הודעת מצב",
+    curationLayerUpdatedTitle: "עדכון אחרון לשכבה",
+    curationLayerTypeTagsAria: "תגי סוג לשכבה",
+    curationUnpublishButton: "הסרה",
+    curationUnpublishButtonAria: "הסרת שכבה מן הבקר",
+    curationUnpublishOneConfirm: "להסיר את \"{{e}}\" מרשימת השכבות המפורסמות?",
+    curationUnpublishOneSuccess: "הוסרה \"{{e}}\" מרשימת הפרסומים.",
+    curationUnpublishOneError: "לא ניתן להסיר שכבה: {{e}}",
+    curationMapUnknownSubmissions: "השכבה המפורסמת מתאימה למספר הגשות או אינה ידועה.",
+    curationMapSubmissionNotInList: "ההגשה {{e}} אינה מופיעה ברשימת ההגשות.",
   },
   en: {
     documentTitle: "OTEF",
@@ -68,6 +133,8 @@ const MESSAGES = {
     navLayers: "Layers",
     navCuration: "Workshop",
     sectionNavigation: "Navigation",
+    navPanGroupLabel: "Pan",
+    navZoomGroupLabel: "Zoom",
     zoomLabel: "Zoom:",
     statusConnected: "Connected",
     statusDisconnected: "Disconnected",
@@ -89,9 +156,74 @@ const MESSAGES = {
     flowLabel: "Flow",
     curatedGroupLabel: "Curated",
     layersOpenPack: "View",
+    layersPackStripLabel: "Pack",
+    layersPackActiveCount: "{{e}}/{{t}} active",
+    layersPackScrollHint: "Swipe horizontally — more packs",
+    ariaLayersPackStrip: "Choose a layer pack",
+    ariaLayerAnimationToggle: "Enable or disable flow animation for this layer",
+    layersBulkVisibility: "All layers in pack",
+    ariaLayersBulkVisibility: "Enable or disable every layer in the selected pack",
     layersBack: "All packs",
     ariaLayersBack: "Back to all packs",
     ariaLayersOpenPack: "View layers in this pack",
+    curationSubmissionsRefreshTitle: "Refresh submissions list",
+    curationSubmissionsRefreshAria: "Refresh submissions list",
+    curationSubmissionsHeading: "Submissions",
+    curationPageTitle: "Curation",
+    curationBackLink: "Controller",
+    curationBackAria: "Open controller",
+    curationHeaderRefresh: "Refresh",
+    curationHeaderRefreshAria: "Refresh",
+    curationDocumentTitle: "OTEF | Curation",
+    curationPublishHeading: "Publish",
+    curationPublishButton: "Publish as OTEF layer",
+    curationSelectSubmissionError: "Select a submission to publish.",
+    curationMissingGroupError: "Missing curated group name.",
+    curationNoFeaturesError: "No current features to publish for this submission.",
+    curationPublishing: "Publishing…",
+    curationPublishedSuccess: "Published “{{e}}”.",
+    curationPublishFailed: "Publish failed: {{e}}",
+    curationUnpublishAllConfirm: "Remove all published curated layers from the remote?",
+    curationUnpublishAllInProgress: "Removing all published curated layers…",
+    curationUnpublishAllRemovedN: "Removed {{n}} published layer(s) from remote.",
+    curationUnpublishAllSuccess: "All published curated layers removed from remote.",
+    curationUnpublishAllError: "Could not unpublish all: {{e}}",
+    curationLoadWorkshopError: "Could not load workshop mode: {{e}}",
+    curationWorkshopOnSuccess:
+      "Workshop auto-publish is on: new submissions can publish automatically when eligible.",
+    curationWorkshopOffSuccess: "Workshop auto-publish is off.",
+    curationUpdateWorkshopError: "Could not update workshop mode: {{e}}",
+    curationPublishedHeading: "Published layers on remote",
+    curationWorkshopAutoPublish: "Workshop auto-publish",
+    curationWorkshopAutoPublishAria: "Workshop auto-publish",
+    curationUnpublishAll: "Unpublish all",
+    curationPublishedLoading: "Loading published curated layers…",
+    curationSubmissionSearchPlaceholder: "Search or choose submission…",
+    curationSubmissionSearchAria: "Search and select submission",
+    curationSubmissionListAria: "Submissions",
+    curationSubmissionsEmpty: "No submissions loaded.",
+    curationSubmissionsNoMatch: "No matching submissions.",
+    curationSubmissionsLoading: "Loading submissions…",
+    curationSubmissionsLoadError: "Could not load submissions: {{e}}",
+    curationNoPublishedLayers: "No published curated layers.",
+    curationLoadingPublished: "Loading published curated layers…",
+    curationLoadPublishedError: "Could not load published curated layers: {{e}}",
+    curationTagTkumaLine: "Tkuma Line",
+    curationTagMemorials: "Memorials",
+    curationSubmissionColorTitle: "Submission color",
+    curationOpenSubmissionForLayer: 'Open submission “{{e}}” for published layer “{{n}}”',
+    curationOpenSubmissionUnnamed: 'Open submission for published layer “{{e}}”',
+    curationPublishedLayerUnknown:
+      'Published layer “{{e}}”: submission unavailable (multiple or unknown); shows status',
+    curationLayerUpdatedTitle: "Layer last updated",
+    curationLayerTypeTagsAria: "Layer type tags",
+    curationUnpublishButton: "Remove",
+    curationUnpublishButtonAria: "Remove layer from remote",
+    curationUnpublishOneConfirm: 'Remove “{{e}}” from published remote layers?',
+    curationUnpublishOneSuccess: 'Removed “{{e}}” from published remote layers.',
+    curationUnpublishOneError: "Could not remove published layer: {{e}}",
+    curationMapUnknownSubmissions: "This published layer maps to multiple/unknown submissions.",
+    curationMapSubmissionNotInList: "Submission {{e}} is not available in the submissions list.",
   },
 };
 
@@ -120,6 +252,9 @@ function readStored() {
   }
   return "he";
 }
+
+/** @type {boolean} */
+let _localeStorageListenerBound = false;
 
 function applyDocumentRoot() {
   if (typeof document === "undefined") return;
@@ -167,9 +302,19 @@ export function applyRemoteChromeI18n() {
     if (!key || !isMessageKey(key)) return;
     el.setAttribute("title", t(key));
   });
-  const title = MESSAGES[_locale].documentTitle;
+  if (typeof document.querySelectorAll === "function") {
+    document.querySelectorAll("[data-i18n-placeholder]").forEach((el) => {
+      const key = el.getAttribute("data-i18n-placeholder");
+      if (!key || !isMessageKey(key)) return;
+      if ("placeholder" in el) {
+        el.placeholder = t(key);
+      }
+    });
+  }
   if (typeof document.title === "string") {
-    document.title = title;
+    const isCuration =
+      typeof document.querySelector === "function" && document.querySelector(".curation-layout");
+    document.title = isCuration ? t("curationDocumentTitle") : MESSAGES[_locale].documentTitle;
   }
 }
 
@@ -220,11 +365,25 @@ export function initLocale() {
   } else {
     setLocale(stored, { force: true });
   }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.addEventListener === "function" &&
+    !_localeStorageListenerBound
+  ) {
+    _localeStorageListenerBound = true;
+    window.addEventListener("storage", (e) => {
+      if (e.key !== LOCALE_STORAGE_KEY) return;
+      const v = e.newValue;
+      if (v === "he" || v === "en") {
+        setLocale(/** @type {LocaleId} */ (v), { force: true });
+      }
+    });
+  }
 }
 
 /**
  * @param {string} key
- * @param {{ n?: string | number }} [vars]
+ * @param {{ n?: string | number; e?: string | number; t?: string | number }} [vars]
  * @returns {string}
  */
 export function t(key, vars = {}) {
@@ -236,6 +395,18 @@ export function t(key, vars = {}) {
     text = text.replace(/\{\{n\}\}/g, String(vars.n));
   } else {
     text = text.replace(/\{\{n\}\}/g, "");
+  }
+  if (vars) {
+    if (vars.e != null) {
+      text = text.replace(/\{\{e\}\}/g, String(vars.e));
+    } else {
+      text = text.replace(/\{\{e\}\}/g, "");
+    }
+    if (vars.t != null) {
+      text = text.replace(/\{\{t\}\}/g, String(vars.t));
+    } else {
+      text = text.replace(/\{\{t\}\}/g, "");
+    }
   }
   return text;
 }

--- a/otef-interactive/frontend/src/shared/curated-supabase-heartbeat.js
+++ b/otef-interactive/frontend/src/shared/curated-supabase-heartbeat.js
@@ -6,6 +6,7 @@
  * one interval + fetch per table so both surfaces refresh after a pull.
  */
 
+import { isOtefCurationEmbedded } from "../curation/curation-embed.js";
 import { shouldTriggerCuratedReload } from "./curated-supabase-reload-trigger.js";
 
 const DEFAULT_INTERVAL_MS = 20000;
@@ -21,6 +22,10 @@ let sharedHb = null;
  * @returns {() => void} stop function
  */
 export function startCuratedSupabaseHeartbeat(options = {}) {
+  if (typeof window !== "undefined" && isOtefCurationEmbedded()) {
+    return () => {};
+  }
+
   const table = options.table || "otef";
   const intervalMs =
     typeof options.intervalMs === "number" && options.intervalMs >= 5000

--- a/otef-interactive/frontend/src/shared/layer-display-glossary.js
+++ b/otef-interactive/frontend/src/shared/layer-display-glossary.js
@@ -1,0 +1,168 @@
+/**
+ * Bilingual display labels for known full layer ids (pack.layer) from processed metadata.
+ * Unknown ids fall back to formatLayerLabelForDisplay(rawLabel) for consistent UI.
+ *
+ * @typedef {"he" | "en"} LayerDisplayLocale
+ */
+
+import { formatLayerLabelForDisplay } from "./layer-name-utils.js";
+
+/**
+ * Stable full id → { he, en }. Keys use the exact ids from manifests / OTEF (including
+ * alternate spellings for the same feature where both appear in runtime).
+ * @type {Record<string, { he: string, en: string }>}
+ */
+const LAYER_DISPLAY_LABELS = {
+  // --- october_7th (from processed metadata / layer report) ---
+  "october_7th.אזור_הרס_אזור": {
+    he: "אזור הרס — אזור",
+    en: "Destruction — area",
+  },
+  "october_7th.אזור_הרס_נקודה": {
+    he: "אזור הרס — נקודה",
+    en: "Destruction — point",
+  },
+  "october_7th.אירוע_נקודתי_רציחה_חטיפה_אזור": {
+    he: "אירוע נקודתי: רציחה/חטיפה — אזור",
+    en: "Point event: fatality or abduction — area",
+  },
+  "october_7th.אירוע_נקודתי_רציחה_חטיפה": {
+    he: "אירוע נקודתי: רציחה/חטיפה",
+    en: "Point event: fatality or abduction",
+  },
+  "october_7th.ביזה_אזור": { he: "ביזה — אזור", en: "Looting — area" },
+  "october_7th.ביזה_נקודה": { he: "ביזה — נקודה", en: "Looting — point" },
+  "october_7th.חדירה_לישוב_אזור": {
+    he: "חדירה לישוב — אזור",
+    en: "Infiltration into a community — area",
+  },
+  "october_7th.חדירה_לישוב_נקודה": {
+    he: "חדירה לישוב — נקודה",
+    en: "Infiltration into a community — point",
+  },
+  "october_7th.חדירה_לישוב-אזור": {
+    he: "חדירה לישוב — אזור",
+    en: "Infiltration into a community — area",
+  },
+  "october_7th.חדירה_לישוב-נקודה": {
+    he: "חדירה לישוב — נקודה",
+    en: "Infiltration into a community — point",
+  },
+  "october_7th.חדירה_לישוב-ציר": {
+    he: "חדירה לישוב — ציר",
+    en: "Infiltration into a community — axis",
+  },
+  "october_7th.חדירה_לישוב_ציר": {
+    he: "חדירה לישוב — ציר",
+    en: "Infiltration into a community — axis",
+  },
+  "october_7th.מאבק_וגבורה_אזור": {
+    he: "מאבק וגבורה — אזור",
+    en: "Fighting and heroism — area",
+  },
+  "october_7th.מאבק_וגבורה_נקודה": {
+    he: "מאבק וגבורה — נקודה",
+    en: "Fighting and heroism — point",
+  },
+  "october_7th.מאבק_וגבורה_ציר": {
+    he: "מאבק וגבורה — ציר",
+    en: "Fighting and heroism — axis",
+  },
+  "october_7th.מאבק_וגבורה-אזור": {
+    he: "מאבק וגבורה — אזור",
+    en: "Fighting and heroism — area",
+  },
+  "october_7th.מאבק_וגבורה-נקודה": {
+    he: "מאבק וגבורה — נקודה",
+    en: "Fighting and heroism — point",
+  },
+  "october_7th.מאבק_וגבורה-ציר": {
+    he: "מאבק וגבורה — ציר",
+    en: "Fighting and heroism — axis",
+  },
+  "october_7th.מוקד_מאבק_וגבורה_אזור": {
+    he: "מוקד מאבק וגבורה — אזור",
+    en: "Fighting and heroism focus — area",
+  },
+  "october_7th.מוקד_מאבק_וגבורה_נקודה": {
+    he: "מוקד מאבק וגבורה — נקודה",
+    en: "Fighting and heroism focus — point",
+  },
+  "october_7th.מוקד_מאבק_וגבורה_ציר": {
+    he: "מוקד מאבק וגבורה — ציר",
+    en: "Fighting and heroism focus — axis",
+  },
+  "october_7th.מרחב_לחימה": { he: "מרחב לחימה", en: "Combat area" },
+  "october_7th.פגיעה_נקודתית_אזור": {
+    he: "פגיעה נקודתית — אזור",
+    en: "Point impact — area",
+  },
+  "october_7th.פגיעה_נקודתית_נקודה": {
+    he: "פגיעה נקודתית — נקודה",
+    en: "Point impact — point",
+  },
+  "october_7th.שטחים_פתוחים_פגועים": {
+    he: "שטחים פתוחים פגועים",
+    en: "Damaged open areas",
+  },
+  // --- projector_base ---
+  "projector_base.sea": { he: "ים", en: "Sea" },
+  "projector_base.רקע_שחור": { he: "רקע שחור", en: "Black background" },
+  "projector_base.tkuma_area_line": {
+    he: "קו אזור תקומה",
+    en: "Tkuma area line",
+  },
+  "projector_base.Tkuma_Area_LIne": {
+    he: "קו אזור תקומה",
+    en: "Tkuma area line",
+  },
+  "projector_base.model_base": { he: "מודל בסיס", en: "Base model" },
+  // --- map_3_future (pack id; layer ids from tests / config) ---
+  "map_3_future.greens": { he: "אזורי ירוק", en: "Greens" },
+  "map_3_future.land_use": { he: "שימושי קרקע", en: "Land use" },
+  "map_3_future.mimushim": { he: "מימושים", en: "Implementations" },
+  "map_3_future.other": { he: "שכבה", en: "Layer" },
+  "map_3_future.x": { he: "שכבה", en: "Layer" },
+  // --- curated Moreshet axis (Supabase) ---
+  "curated_moresht_axis.pink_line_parking": {
+    he: "חניה ציר ורוד",
+    en: "Pink line parking",
+  },
+};
+
+/**
+ * @param {string} fullLayerId
+ * @param {LayerDisplayLocale} locale
+ * @param {string} rawLabel
+ * @param {string[] | null | undefined} [fullLayerIds] try each id; first glossary hit wins
+ * @returns {string}
+ */
+export function getLayerDisplayLabel(
+  fullLayerId,
+  locale,
+  rawLabel,
+  fullLayerIds = undefined,
+) {
+  const loc = locale === "en" ? "en" : "he";
+  const tryIds = [];
+  if (fullLayerIds && fullLayerIds.length > 0) {
+    for (const id of fullLayerIds) {
+      if (id != null && String(id).trim() !== "")
+        tryIds.push(String(id));
+    }
+  } else if (fullLayerId != null && String(fullLayerId).trim() !== "") {
+    tryIds.push(String(fullLayerId));
+  }
+  const seen = new Set();
+  for (const id of tryIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const row = LAYER_DISPLAY_LABELS[id];
+    if (!row) continue;
+    const s = row[loc];
+    if (s != null && String(s).trim() !== "") return String(s);
+  }
+  return formatLayerLabelForDisplay(rawLabel);
+}
+
+export { LAYER_DISPLAY_LABELS };

--- a/otef-interactive/frontend/src/shared/layer-display-glossary.js
+++ b/otef-interactive/frontend/src/shared/layer-display-glossary.js
@@ -105,6 +105,45 @@ const LAYER_DISPLAY_LABELS = {
     he: "שטחים פתוחים פגועים",
     en: "Damaged open areas",
   },
+  // Same features as above; layer ids in october_7th/manifest.json use hyphens in places.
+  "october_7th.אזור_הרס-אזור": {
+    he: "אזור הרס — אזור",
+    en: "Destruction — area",
+  },
+  "october_7th.אזור_הרס-נקודה": {
+    he: "אזור הרס — נקודה",
+    en: "Destruction — point",
+  },
+  "october_7th.אירוע_נקודתי-רציחה_חטיפה": {
+    he: "אירוע נקודתי: רציחה/חטיפה",
+    en: "Point event: fatality or abduction",
+  },
+  "october_7th.אירוע_נקודתי-רציחה_חטיפה-אזור": {
+    he: "אירוע נקודתי: רציחה/חטיפה — אזור",
+    en: "Point event: fatality or abduction — area",
+  },
+  "october_7th.ביזה-אזור": { he: "ביזה — אזור", en: "Looting — area" },
+  "october_7th.ביזה-נקודה": { he: "ביזה — נקודה", en: "Looting — point" },
+  "october_7th.בין_1_ל15_עדויות": {
+    he: "עדויות — גילאי 1–15",
+    en: "Testimonies — ages 1–15",
+  },
+  "october_7th.בין_16_ל40_עדויות": {
+    he: "עדויות — גילאי 16–40",
+    en: "Testimonies — ages 16–40",
+  },
+  "october_7th.מעל_41_עדויות": {
+    he: "עדויות — מעל גיל 41",
+    en: "Testimonies — age 41+",
+  },
+  "october_7th.פגיעה_נקודתית-אזור": {
+    he: "פגיעה נקודתית — אזור",
+    en: "Point impact — area",
+  },
+  "october_7th.פגיעה_נקודתית-נקודה": {
+    he: "פגיעה נקודתית — נקודה",
+    en: "Point impact — point",
+  },
   // --- projector_base ---
   "projector_base.sea": { he: "ים", en: "Sea" },
   "projector_base.רקע_שחור": { he: "רקע שחור", en: "Black background" },
@@ -118,11 +157,113 @@ const LAYER_DISPLAY_LABELS = {
   },
   "projector_base.model_base": { he: "מודל בסיס", en: "Base model" },
   // --- map_3_future (pack id; layer ids from tests / config) ---
-  "map_3_future.greens": { he: "אזורי ירוק", en: "Greens" },
+  "map_3_future.greens": { he: "ירוקים", en: "Greens" },
   "map_3_future.land_use": { he: "שימושי קרקע", en: "Land use" },
   "map_3_future.mimushim": { he: "מימושים", en: "Implementations" },
   "map_3_future.other": { he: "שכבה", en: "Layer" },
   "map_3_future.x": { he: "שכבה", en: "Layer" },
+  // --- future_development (runtime pack ids from manifests / layer report) ---
+  "future_development.אנדרטאות_ומוקדי_הנצחה": {
+    he: "אנדרטאות ומוקדי הנצחה",
+    en: "Monuments and memorial sites",
+  },
+  "future_development.הקו_הורוד": { he: "הקו הורוד", en: "Pink line" },
+  "future_development.הציר_הורוד_חדש": {
+    he: "הציר הורוד החדש",
+    en: "New pink axis",
+  },
+  "future_development.מוזיאונים_מרכזי_מבקרים_ומוקדי_תרבות": {
+    he: "מוזיאונים, מרכזי מבקרים ומוקדי תרבות",
+    en: "Museums, visitor centers, and culture hubs",
+  },
+  "future_development.מוקדי_מורשת": { he: "מוקדי מורשת", en: "Heritage focal points" },
+  "future_development.מוקדים_ארכאולוגיים": {
+    he: "מוקדים ארכאולוגיים",
+    en: "Archaeological sites",
+  },
+  "future_development.מורשת_מוצע": { he: "מורשת — מוצע", en: "Heritage — proposed" },
+  "future_development.מורשת_קיים": { he: "מורשת — קיים", en: "Heritage — existing" },
+  "future_development.מורשת-מוצע": { he: "מורשת — מוצע", en: "Heritage — proposed" },
+  "future_development.מורשת-קיים": { he: "מורשת — קיים", en: "Heritage — existing" },
+  "future_development.מימושים": { he: "מימושים", en: "Zoning build-out" },
+  "future_development.מתחמי_דיור": { he: "מתחמי דיור", en: "Housing clusters" },
+  "future_development.ציר_232": { he: "ציר 232", en: "Route 232 corridor" },
+  "future_development.יציאה_כביש": {
+    he: "יציאת כביש",
+    en: "Road exit",
+  },
+  // --- greens ---
+  "greens.גן_לאומי": { he: "גן לאומי", en: "National park" },
+  "greens.חקלאות": { he: "חקלאות", en: "Agriculture" },
+  "greens.יער_טבעי": { he: "יער טבעי", en: "Natural forest" },
+  "greens.יער_פארק": { he: "יער פארק", en: "Park forest" },
+  "greens.יערות_קקל": { he: "יערות קק\"ל", en: "KKL forests" },
+  "greens.מישורי_הצפה": { he: "מישורי הצפה", en: "Floodplains" },
+  "greens.מסדרונות_אקולוגיים": {
+    he: "מסדרונות אקולוגיים",
+    en: "Ecological corridors",
+  },
+  "greens.נחלים": { he: "נחלים", en: "Streams" },
+  "greens.צוואר_בקבוק": { he: "צוואר בקבוק", en: "Bottleneck" },
+  "greens.שמורות_טבע": { he: "שמורות טבע", en: "Nature reserves" },
+  // --- land_use ---
+  "land_use.אחסנה": { he: "אחסנה", en: "Storage" },
+  "land_use.בית_עלמין": { he: "בית עלמין", en: "Cemetery" },
+  "land_use.חניון": { he: "חניון", en: "Parking" },
+  "land_use.חקלאות_מרעה_ותעשייה": {
+    he: "חקלאות, מרעה ותעשייה",
+    en: "Agriculture, pasture, and industry",
+  },
+  "land_use.כרייה_וחציבה": { he: "כרייה וחציבה", en: "Quarries" },
+  "land_use.מגורים": { he: "מגורים", en: "Residential" },
+  "land_use.מוסדות_ציבוריים": { he: "מוסדות ציבוריים", en: "Public institutions" },
+  "land_use.מסחר_ומשרדים": { he: "מסחר ומשרדים", en: "Commerce and offices" },
+  "land_use.מעורב_עם_מגורים": { he: "מעורב עם מגורים", en: "Mixed with residential" },
+  "land_use.מעורב_עם_מסחר": { he: "מעורב עם מסחר", en: "Mixed with commerce" },
+  "land_use.מתקני_הנדסה": { he: "מתקני הנדסה", en: "Engineering facilities" },
+  "land_use.ספורט": { he: "ספורט", en: "Sports" },
+  "land_use.שטח_לדרכים": { he: "שטח לדרכים", en: "Road reserve" },
+  "land_use.שטחי_אש": { he: "שטחי אש", en: "Fire zones" },
+  // Runtime id variant (trailing underscore in manifest)
+  "land_use.שטחי_אש_": { he: "שטחי אש", en: "Fire zones" },
+  "land_use.שטחים_פתוחים": { he: "שטחים פתוחים", en: "Open space" },
+  "land_use.תחבורה": { he: "תחבורה", en: "Transportation" },
+  "land_use.תיירות_ונופש": { he: "תיירות ונופש", en: "Tourism and leisure" },
+  "land_use.תעסוקה": { he: "תעסוקה", en: "Employment" },
+  "land_use.תעשייה_ומלאכה": { he: "תעשייה ומלאכה", en: "Industry and crafts" },
+  // --- muniplicity_transport (typo id in layers manifest) ---
+  "muniplicity_transport.במה": { he: "במה", en: "Skills area" },
+  "muniplicity_transport.דרכי_עפר": { he: "דרכי עפר", en: "Dirt roads" },
+  "muniplicity_transport.דרכים_אזוריות": { he: "דרכים אזוריים", en: "Regional roads" },
+  "muniplicity_transport.דרכים_ארציות": { he: "דרכים ארציים", en: "National roads" },
+  "muniplicity_transport.דרכים_מקומיות": { he: "דרכים מקומיות", en: "Local roads" },
+  "muniplicity_transport.מועצות_אזוריות": { he: "מועצות אזוריות", en: "Regional councils" },
+  "muniplicity_transport.מועצות_אזוריות_מתאר": {
+    he: "מועצות אזוריות — מתאר",
+    en: "Regional councils (cartographic outline)",
+  },
+  "muniplicity_transport.מסלולי_רכבת": { he: "מסלולי רכבת", en: "Railway alignments" },
+  "muniplicity_transport.מרכז_תחבורה_מתוכנן": {
+    he: "מרכז תחבורה מתוכנן",
+    en: "Planned transit hub",
+  },
+  "muniplicity_transport.מרכז_תחבורה_קיים": {
+    he: "מרכז תחבורה קיים",
+    en: "Existing transit hub",
+  },
+  "muniplicity_transport.סינגלים": { he: "סינגלים", en: "Singletrack" },
+  "muniplicity_transport.סעד": { he: "סעד", en: "Aid route" },
+  "muniplicity_transport.שביל_הנגב_המערבי": {
+    he: "שביל הנגב המערבי",
+    en: "Western Negev trail",
+  },
+  "muniplicity_transport.שבילי_אופניים": { he: "שבילי אופניים", en: "Bicycle paths" },
+  "muniplicity_transport.שבילי_אופניים_שקמה": {
+    he: "שבילי אופניים (שקמה)",
+    en: "Bicycle paths (Shikma)",
+  },
+  "muniplicity_transport.שבילים": { he: "שבילים", en: "Trails" },
+  "muniplicity_transport.תחנות_רכבת": { he: "תחנות רכבת", en: "Railway stations" },
   // --- curated Moreshet axis (Supabase) ---
   "curated_moresht_axis.pink_line_parking": {
     he: "חניה ציר ורוד",

--- a/otef-interactive/frontend/src/shared/layer-name-utils.js
+++ b/otef-interactive/frontend/src/shared/layer-name-utils.js
@@ -57,13 +57,30 @@ function parseLayerNameWithGeometrySuffix(name) {
   };
 }
 
+/**
+ * Human-readable label for layer rows and lists. Replaces underscore/hyphen runs
+ * with spaces and collapses whitespace. For UI only; never use for layer ids,
+ * fullLayerIds, or API keys.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function formatLayerLabelForDisplay(name) {
+  if (name == null || typeof name !== "string") return "";
+  const trimmed = name.trim();
+  if (trimmed === "") return "";
+  return trimmed.replace(/[\s_\-]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
 if (typeof window !== "undefined") {
   window.normalizeLayerBaseName = normalizeLayerBaseName;
   window.parseLayerNameWithGeometrySuffix = parseLayerNameWithGeometrySuffix;
+  window.formatLayerLabelForDisplay = formatLayerLabelForDisplay;
   window.LayerNameUtils = {
     normalizeLayerBaseName,
     parseLayerNameWithGeometrySuffix,
+    formatLayerLabelForDisplay,
   };
 }
 
-export { normalizeLayerBaseName, parseLayerNameWithGeometrySuffix };
+export { normalizeLayerBaseName, parseLayerNameWithGeometrySuffix, formatLayerLabelForDisplay };

--- a/otef-interactive/frontend/src/shared/layer-state-helper.js
+++ b/otef-interactive/frontend/src/shared/layer-state-helper.js
@@ -18,6 +18,38 @@ import {
 } from "../map-utils/curated-pink-axis-state.js";
 
 /**
+ * Preserve API-only fields needed for remote UI (workshop color swatches, etc.).
+ * Intentionally narrow allowlist — do not spread entire API objects.
+ *
+ * @param {object|null|undefined} src
+ * @returns {Record<string, unknown>}
+ */
+function pickApiLayerOverlayFields(src) {
+  if (!src || typeof src !== "object") return {};
+  const keys = [
+    "displayName",
+    "display_name",
+    "display_color",
+    "submission_color",
+    "displayColor",
+    "submissionColor",
+    "submission_id",
+    "submissionId",
+    "color",
+    "fillColor",
+    "style",
+    "metadata",
+    "properties",
+    "fullLayerIds",
+  ];
+  const out = {};
+  for (const k of keys) {
+    if (src[k] !== undefined) out[k] = src[k];
+  }
+  return out;
+}
+
+/**
  * Parse fullLayerId into groupId and layerId using "first dot" split.
  * Supports layer ids that contain dots (e.g. "map_3.layer.with.dots").
  *
@@ -151,6 +183,7 @@ function getEffectiveLayerGroups() {
           const layerState = state.layers?.find((l) => l.id === layer.id);
           return {
             ...layer,
+            ...pickApiLayerOverlayFields(layerState),
             name: layerState?.displayName ?? layer.name ?? layer.id,
             enabled: layerState ? !!layerState.enabled : defaultLayerEnabled(reg.id, layer.id),
           };
@@ -205,6 +238,7 @@ function getEffectiveLayerGroups() {
       name: explicitName || derivedName,
       enabled: !!cg.enabled,
       layers: (cg.layers || []).map((l) => ({
+        ...pickApiLayerOverlayFields(l),
         id: l.id,
         name: l.displayName || l.id,
         enabled: !!l.enabled,
@@ -282,7 +316,7 @@ function coalesceCuratedGroups(groups) {
 
   const mergedCuratedGroup = {
     id: "curated_moresht_axis",
-    name: "Moreshet Axis",
+    name: "Workshop",
     enabled: allEnabled,
     layers: mergedLayers,
   };

--- a/otef-interactive/tests/contracts/html-entrypoint-contract.test.js
+++ b/otef-interactive/tests/contracts/html-entrypoint-contract.test.js
@@ -85,6 +85,6 @@ test("remote-controller locale toggle contract (delta)", () => {
   expect(toggleRegion[0]).toMatch(/role="group"/);
   expect(toggleRegion[0]).toMatch(/data-i18n-aria="localeGroupAria"/);
 
-  expect(remote).toMatch(/id="remoteLocaleHe"[^>]*>[\s\S]*?עב/);
-  expect(remote).toMatch(/id="remoteLocaleEn"[^>]*>[\s\S]*?\ben\b/);
+  expect(remote).toMatch(/id="remoteLocaleHe"[^>]*>[\s\S]*?עברית/);
+  expect(remote).toMatch(/id="remoteLocaleEn"[^>]*>[\s\S]*?English/);
 });

--- a/otef-interactive/tests/contracts/html-entrypoint-contract.test.js
+++ b/otef-interactive/tests/contracts/html-entrypoint-contract.test.js
@@ -71,3 +71,20 @@ test("remote-controller shell: Hebrew default, tab regions, and stable mount ids
   expect(remote).toMatch(/\bid="zoomSlider"/);
   expect(remote).toMatch(/\bid="joystickZone"/);
 });
+
+test("remote-controller locale toggle contract (delta)", () => {
+  const remote = fs.readFileSync(
+    path.resolve(__dirname, "../../frontend/remote-controller.html"),
+    "utf8",
+  );
+
+  const toggleRegion = remote.match(
+    /class="remote-locale-toggle"[\s\S]*?\bid="remoteLocaleToggle"/i,
+  );
+  expect(toggleRegion).toBeTruthy();
+  expect(toggleRegion[0]).toMatch(/role="group"/);
+  expect(toggleRegion[0]).toMatch(/data-i18n-aria="localeGroupAria"/);
+
+  expect(remote).toMatch(/id="remoteLocaleHe"[^>]*>[\s\S]*?עב/);
+  expect(remote).toMatch(/id="remoteLocaleEn"[^>]*>[\s\S]*?\ben\b/);
+});

--- a/otef-interactive/tests/contracts/html-entrypoint-contract.test.js
+++ b/otef-interactive/tests/contracts/html-entrypoint-contract.test.js
@@ -29,3 +29,45 @@ test("projection/remote/curation pages load single module entrypoints", () => {
   expect(remote.includes('src="js/remote/remote-controller.js"')).toBe(false);
   expect(curation.includes('src="js/curation/curation.js"')).toBe(false);
 });
+
+test("remote-controller embeds curation workshop iframe with embed heartbeat contract flag", () => {
+  const remote = fs.readFileSync(
+    path.resolve(__dirname, "../../frontend/remote-controller.html"),
+    "utf8",
+  );
+  expect(remote.includes('src="curation.html?embed=1"')).toBe(true);
+  expect(/<iframe\b[^>]*\bid="remoteCurationFrame"/i.test(remote)).toBe(true);
+});
+
+test("remote-controller shell: Hebrew default, tab regions, and stable mount ids", () => {
+  const remote = fs.readFileSync(
+    path.resolve(__dirname, "../../frontend/remote-controller.html"),
+    "utf8",
+  );
+
+  expect(remote).toMatch(/<html[^>]*\blang="he"/i);
+  expect(remote).toMatch(/\bid="table-switcher"/);
+  expect(remote).toMatch(/\bid="warningOverlay"/);
+  expect(remote).toMatch(/\bid="remoteMain"/);
+  expect(remote).toMatch(/\bid="remoteTabPanels"/);
+  expect(remote).toMatch(/\bid="remoteBottomNav"/);
+  expect(remote).toMatch(/\brole="tablist"/);
+
+  expect(remote).toMatch(
+    /data-remote-tab="navigation"[^>]*\bid="remote-panel-navigation"/i,
+  );
+  expect(remote).toMatch(/data-remote-tab="layers"[^>]*\bid="remote-panel-layers"/i);
+  expect(remote).toMatch(/data-remote-tab="curation"[^>]*\bid="remote-panel-curation"/i);
+
+  expect(remote).toMatch(/\bid="remote-tab-navigation"[^>]*\baria-controls="remote-panel-navigation"/i);
+  expect(remote).toMatch(/\bid="remote-tab-layers"[^>]*\baria-controls="remote-panel-layers"/i);
+  expect(remote).toMatch(/\bid="remote-tab-curation"[^>]*\baria-controls="remote-panel-curation"/i);
+
+  expect(remote).toMatch(/\bid="remoteLayerHost"/);
+  expect(remote).toMatch(/\bid="layerSheet"/);
+  expect(remote).toMatch(/\bid="layerPanelContent"/);
+  expect(remote).toMatch(/\bid="remoteLocaleToggle"/);
+  expect(remote).toMatch(/\bid="panNorth"/);
+  expect(remote).toMatch(/\bid="zoomSlider"/);
+  expect(remote).toMatch(/\bid="joystickZone"/);
+});

--- a/otef-interactive/tests/curation/curation-embed-flag.test.js
+++ b/otef-interactive/tests/curation/curation-embed-flag.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest";
+import {
+  getCurationEmbedModeFromSearch,
+  isOtefCurationEmbedded,
+  isOtefCurationInIframeContext,
+} from "../../frontend/src/curation/curation-embed.js";
+
+describe("curation embed flag", () => {
+  test("getCurationEmbedModeFromSearch accepts embed=1 and embed=true", () => {
+    expect(getCurationEmbedModeFromSearch("?embed=1")).toBe(true);
+    expect(getCurationEmbedModeFromSearch("?embed=true")).toBe(true);
+    expect(getCurationEmbedModeFromSearch("embed=1")).toBe(true);
+    expect(getCurationEmbedModeFromSearch("?embed=0")).toBe(false);
+    expect(getCurationEmbedModeFromSearch("")).toBe(false);
+    expect(getCurationEmbedModeFromSearch("?other=1")).toBe(false);
+  });
+
+  test("isOtefCurationInIframeContext is false when self equals top", () => {
+    const prev = globalThis.window;
+    try {
+      const topRef = {};
+      globalThis.window = { self: topRef, top: topRef };
+      expect(isOtefCurationInIframeContext()).toBe(false);
+    } finally {
+      globalThis.window = prev;
+    }
+  });
+
+  test("isOtefCurationInIframeContext is true in a nested frame (self !== top)", () => {
+    const prev = globalThis.window;
+    try {
+      globalThis.window = { self: {}, top: {} };
+      expect(isOtefCurationInIframeContext()).toBe(true);
+    } finally {
+      globalThis.window = prev;
+    }
+  });
+
+  test("isOtefCurationEmbedded is true only with embed flag and iframe context", () => {
+    const prev = globalThis.window;
+    try {
+      const topRef = {};
+      globalThis.window = {
+        location: { search: "?embed=1" },
+        self: topRef,
+        top: topRef,
+      };
+      expect(isOtefCurationEmbedded()).toBe(false);
+
+      globalThis.window = {
+        location: { search: "?embed=1" },
+        self: {},
+        top: {},
+      };
+      expect(isOtefCurationEmbedded()).toBe(true);
+
+      globalThis.window = {
+        location: { search: "" },
+        self: {},
+        top: {},
+      };
+      expect(isOtefCurationEmbedded()).toBe(false);
+    } finally {
+      globalThis.window = prev;
+    }
+  });
+});

--- a/otef-interactive/tests/curation/curation-published-layers-metadata.test.js
+++ b/otef-interactive/tests/curation/curation-published-layers-metadata.test.js
@@ -1,10 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
+import { setLocale } from "../../frontend/src/remote/remote-locale.js";
 import { chipClassForTag } from "../../frontend/src/curation/curation-submissions.js";
 import { sanitizeCssColor } from "../../frontend/src/curation/curation-color-utils.js";
 import {
+  derivePublishedLayerUiFields,
   extractColorFromGeojsonData,
   extractInfoTagsFromGeojsonData,
   formatUpdatedAtForUi,
@@ -25,6 +27,10 @@ describe("chipClassForTag (shared with published layer chips)", () => {
 });
 
 describe("published layer metadata helpers", () => {
+  beforeEach(() => {
+    setLocale("he", { force: true });
+  });
+
   test("extractColorFromGeojsonData reads stroke from first feature", () => {
     const c = extractColorFromGeojsonData({
       type: "FeatureCollection",
@@ -156,10 +162,48 @@ describe("published layer metadata helpers", () => {
     expect(formatUpdatedAtForUi("not-a-date")).toBe("—");
   });
 
-  test("formatUpdatedAtForUi formats ISO timestamps", () => {
+  test("formatUpdatedAtForUi formats ISO timestamps (he-IL, 24h)", () => {
     const s = formatUpdatedAtForUi("2026-04-17T12:30:00.000Z");
     expect(s).not.toBe("—");
     expect(s.length).toBeGreaterThan(6);
+    expect(s).not.toMatch(/\b[AP]M\b/i);
+  });
+
+  test("formatUpdatedAtForUi uses en-US when locale is en", () => {
+    setLocale("en", { force: true });
+    const s = formatUpdatedAtForUi("2026-04-17T12:30:00.000Z");
+    expect(s).not.toBe("—");
+    expect(s).not.toMatch(/\b[AP]M\b/i);
+  });
+
+  test("derivePublishedLayerUiFields returns updatedAtRaw (ISO) not a formatted label", () => {
+    const iso = "2026-04-17T12:30:00.000Z";
+    const ui = derivePublishedLayerUiFields({
+      updated_at: iso,
+      data: { type: "FeatureCollection", features: [] },
+    });
+    expect(ui.updatedAtRaw).toBe(iso);
+    expect(ui).not.toHaveProperty("updatedAtLabel");
+    expect(ui.colorRaw).toBe(null);
+    expect(ui.infoTags).toEqual([]);
+  });
+
+  test("derivePublishedLayerUiFields uses updatedAt / modified_at fallbacks and empty raw when missing", () => {
+    expect(
+      derivePublishedLayerUiFields({
+        updatedAt: "2026-01-02T00:00:00.000Z",
+        data: { type: "FeatureCollection", features: [] },
+      }).updatedAtRaw,
+    ).toBe("2026-01-02T00:00:00.000Z");
+    expect(
+      derivePublishedLayerUiFields({
+        modified_at: "2026-03-04T00:00:00.000Z",
+        data: { type: "FeatureCollection", features: [] },
+      }).updatedAtRaw,
+    ).toBe("2026-03-04T00:00:00.000Z");
+    expect(derivePublishedLayerUiFields({ data: { type: "FeatureCollection", features: [] } }).updatedAtRaw).toBe(
+      "",
+    );
   });
 });
 

--- a/otef-interactive/tests/curation/curation-published-layers-metadata.test.js
+++ b/otef-interactive/tests/curation/curation-published-layers-metadata.test.js
@@ -12,6 +12,7 @@ import {
   formatUpdatedAtForUi,
   getGeojsonDataFromGisLayerRecord,
   normalizeGisLayerGeojsonInput,
+  resolvePublishedLayerInfoTags,
 } from "../../frontend/src/curation/curation-published-layers.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -186,6 +187,34 @@ describe("published layer metadata helpers", () => {
     expect(ui).not.toHaveProperty("updatedAtLabel");
     expect(ui.colorRaw).toBe(null);
     expect(ui.infoTags).toEqual([]);
+  });
+
+  test("resolvePublishedLayerInfoTags uses submission type_label when id maps to a known row (parity with combobox)", () => {
+    const geoOnlyTkuma = ["Tkuma Line"];
+    const getLabel = (id) => (String(id).toLowerCase() === "abc" ? "Mixed" : null);
+    expect(resolvePublishedLayerInfoTags("abc", geoOnlyTkuma, getLabel)).toEqual([
+      "Tkuma Line",
+      "Memorials",
+    ]);
+  });
+
+  test("resolvePublishedLayerInfoTags falls back to GeoJSON tags when no submission id", () => {
+    expect(
+      resolvePublishedLayerInfoTags("", ["Tkuma Line"], () => "Mixed"),
+    ).toEqual(["Tkuma Line"]);
+  });
+
+  test("resolvePublishedLayerInfoTags falls back to GeoJSON when type_label unknown for id", () => {
+    const geo = ["Memorials"];
+    expect(
+      resolvePublishedLayerInfoTags("not-in-list", geo, () => null),
+    ).toEqual(["Memorials"]);
+  });
+
+  test("resolvePublishedLayerInfoTags single-tag submission matches combobox (Memorials only)", () => {
+    expect(
+      resolvePublishedLayerInfoTags("x", ["Tkuma Line"], () => "Memorials"),
+    ).toEqual(["Memorials"]);
   });
 
   test("derivePublishedLayerUiFields uses updatedAt / modified_at fallbacks and empty raw when missing", () => {

--- a/otef-interactive/tests/curation/curation-save-flow-contract.test.js
+++ b/otef-interactive/tests/curation/curation-save-flow-contract.test.js
@@ -47,9 +47,30 @@ test("submission list loads from all-submissions API (searchable list, no projec
   expect(subs.includes("has_history")).toBe(true);
 });
 
-test("curation sidebar title is plain submissions", () => {
+test("curation.html embed flag in inline script; submissions refresh i18n or static a11y", () => {
   const html = readCurationHtml();
-  expect(html.includes("<h2>Submissions</h2>")).toBe(true);
+  const inlineBodies = [
+    ...html.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi),
+  ].map((m) => m[1]);
+  expect(inlineBodies.some((body) => body.includes("curation-embed"))).toBe(true);
+  expect(html.includes('id="curationSubmissionsRefresh"')).toBe(true);
+  const btnOpen = html.match(/<button\b[\s\S]*?\bid="curationSubmissionsRefresh"[\s\S]*?>/);
+  expect(btnOpen).toBeTruthy();
+  const tag = btnOpen[0];
+  const hasI18n =
+    tag.includes('data-i18n-title="curationSubmissionsRefreshTitle"') &&
+    tag.includes('data-i18n-aria="curationSubmissionsRefreshAria"');
+  const hasStatic = /\btitle="/i.test(tag) && /\baria-label="/i.test(tag);
+  expect(hasI18n || hasStatic).toBe(true);
+});
+
+test("curation sidebar submissions section, embed class, and refresh control", () => {
+  const html = readCurationHtml();
+  expect(html.includes("curation-embed")).toBe(true);
+  expect(
+    /<\s*h2[^>]*\bdata-i18n="curationSubmissionsHeading"[^>]*>/.test(html),
+  ).toBe(true);
+  expect(html.includes('id="curationSubmissionsRefresh"')).toBe(true);
   expect(html.includes("Submissions (combined)")).toBe(false);
   expect(html.includes('id="curationSubmissionTypeBadge"')).toBe(false);
   expect(html.includes('id="curationSubmissionSelectedTags"')).toBe(true);

--- a/otef-interactive/tests/curation/curation-save-flow-contract.test.js
+++ b/otef-interactive/tests/curation/curation-save-flow-contract.test.js
@@ -67,9 +67,8 @@ test("curation.html embed flag in inline script; submissions refresh i18n or sta
 test("curation sidebar submissions section, embed class, and refresh control", () => {
   const html = readCurationHtml();
   expect(html.includes("curation-embed")).toBe(true);
-  expect(
-    /<\s*h2[^>]*\bdata-i18n="curationSubmissionsHeading"[^>]*>/.test(html),
-  ).toBe(true);
+  expect(html.includes('id="curationSubmissionCombo"')).toBe(true);
+  expect(html.includes('id="curationSubmissionSearch"')).toBe(true);
   expect(html.includes('id="curationSubmissionsRefresh"')).toBe(true);
   expect(html.includes("Submissions (combined)")).toBe(false);
   expect(html.includes('id="curationSubmissionTypeBadge"')).toBe(false);

--- a/otef-interactive/tests/curation/curation-simplified-ui-contract.test.js
+++ b/otef-interactive/tests/curation/curation-simplified-ui-contract.test.js
@@ -38,6 +38,33 @@ describe("curation simplified UI (HTML + orchestration contracts)", () => {
     expect(html.includes('id="curationModalPublish"')).toBe(false);
   });
 
+  test("T27: curation.html has no h2 in submissions chrome or publish blocks; combo + publish remain", () => {
+    const html = readUtf8(CURATION_HTML);
+    expect((html.match(/<h2\b/gi) || []).length).toBe(0);
+    expect(html.includes('id="curationSubmissionCombo"')).toBe(true);
+    expect(html.includes('id="curationPublish"')).toBe(true);
+    const bodyIdx = html.indexOf("<body");
+    const fromBody = bodyIdx >= 0 ? html.slice(bodyIdx) : html;
+    const comboIdx = fromBody.indexOf('id="curationSubmissionCombo"');
+    const comboSlice = fromBody.slice(comboIdx, comboIdx + 8000);
+    expect(comboSlice.includes("curation-submissions-toolbar")).toBe(false);
+    expect((comboSlice.match(/<h2\b/gi) || []).length).toBe(0);
+    const pubIdx = fromBody.indexOf('id="curationPublish"');
+    expect(pubIdx).toBeGreaterThan(0);
+    const publishBlock = fromBody.slice(
+      Math.max(0, pubIdx - 400),
+      fromBody.indexOf("</section>", pubIdx) + 12,
+    );
+    expect((publishBlock.match(/<h2\b/gi) || []).length).toBe(0);
+  });
+
+  test("T27: published section label is a div with role=heading (aria-level=2), not h2", () => {
+    const html = readUtf8(CURATION_HTML);
+    expect(html).toMatch(/class="curation-published-heading"[^>]*\brole="heading"/);
+    expect(html).toMatch(/class="curation-published-heading"[^>]*\baria-level="2"/);
+    expect((html.match(/<h2\b/gi) || []).length).toBe(0);
+  });
+
   test("curation.js loads features with current-only revisions and omits map / edit flows", () => {
     const js = readUtf8(CURATION_JS);
     const publishGeojsonJs = readUtf8(CURATION_PUBLISH_GEOJSON_JS);

--- a/otef-interactive/tests/curation/curation-simplified-ui-contract.test.js
+++ b/otef-interactive/tests/curation/curation-simplified-ui-contract.test.js
@@ -61,6 +61,6 @@ describe("curation simplified UI (HTML + orchestration contracts)", () => {
     expect(js.includes("setPublishModeSegmentState")).toBe(false);
     expect(js.includes("publishSelectedCuratedLayer")).toBe(true);
     expect(js.includes("remote controller Layers sheet")).toBe(false);
-    expect(js.includes('Published "')).toBe(true);
+    expect(js.includes("curationPublishedSuccess")).toBe(true);
   });
 });

--- a/otef-interactive/tests/curation/curation-submissions-ui-contract.test.js
+++ b/otef-interactive/tests/curation/curation-submissions-ui-contract.test.js
@@ -119,6 +119,21 @@ describe("curation submissions list UI (HTML + source contracts)", () => {
     expect(html.includes('id="curationSubmissionSummary"')).toBe(false);
   });
 
+  test("submissions refresh is on combo row, not in title toolbar", () => {
+    const html = readCurationHtml();
+    expect(html.includes('class="curation-submission-combo-row"')).toBe(true);
+    const bodyIdx = html.indexOf("<body");
+    const fromBody = bodyIdx >= 0 ? html.slice(bodyIdx) : html;
+    const rowIdx = fromBody.indexOf("curation-submission-combo-row");
+    expect(rowIdx).toBeGreaterThan(0);
+    const rowSlice = fromBody.slice(rowIdx, rowIdx + 2000);
+    expect(rowSlice.includes("curationSubmissionComboField")).toBe(true);
+    expect(rowSlice.includes("curationSubmissionsRefresh")).toBe(true);
+    const toolbarIdx = fromBody.indexOf("curation-submissions-toolbar");
+    const toolbarSlice = fromBody.slice(toolbarIdx, toolbarIdx + 500);
+    expect(toolbarSlice.includes("curationSubmissionsRefresh")).toBe(false);
+  });
+
   test("submissions module renders type chips (Tkuma Line / Memorials), not History", () => {
     const src = readCurationSubmissionsSource();
     expect(src.includes("curation-chip-type")).toBe(true);

--- a/otef-interactive/tests/curation/curation-workshop-mode-contract.test.js
+++ b/otef-interactive/tests/curation/curation-workshop-mode-contract.test.js
@@ -39,6 +39,6 @@ describe("curation workshop mode (API + UI contracts)", () => {
   test("curation.html includes workshop auto-publish control", () => {
     const html = readUtf8(CURATION_HTML);
     expect(html.includes('id="curationWorkshopAutoPublish"')).toBe(true);
-    expect(html.includes("Workshop auto-publish")).toBe(true);
+    expect(html.includes('data-i18n="curationWorkshopAutoPublish"')).toBe(true);
   });
 });

--- a/otef-interactive/tests/remote/layer-pack-labels-contract.test.js
+++ b/otef-interactive/tests/remote/layer-pack-labels-contract.test.js
@@ -14,6 +14,10 @@ describe("layer-pack-display-names (contract)", () => {
   test("getPackDisplayLabel matches PACK_LABELS after normalizePackId when direct key misses", () => {
     expect(getPackDisplayLabel("map-3 future", "en")).toBe("Map 3 — future");
     expect(getPackDisplayLabel("MUNICIPALITY transport", "he")).toBe("תחבורה מוניציפלית");
+    // layers/layers-manifest.json pack id (distinct spelling)
+    expect(getPackDisplayLabel("muniplicity_transport", "en")).toBe("Municipal transport");
+    expect(getPackDisplayLabel("greens", "he")).toBe("ירוקים");
+    expect(getPackDisplayLabel("projector_base", "he")).toBe("בסיס מקרן");
   });
 
   test("REQUIRED_PACK_IDS lists known packs", () => {
@@ -23,8 +27,12 @@ describe("layer-pack-display-names (contract)", () => {
       "map_3_future",
       "curated_moresht_axis",
       "future_development",
+      "gaza",
+      "greens",
+      "land_use",
       "municipality_transport",
       "municpality_transport",
+      "muniplicity_transport",
       "curated",
     ]);
   });

--- a/otef-interactive/tests/remote/layer-pack-labels-contract.test.js
+++ b/otef-interactive/tests/remote/layer-pack-labels-contract.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vitest";
+import {
+  REQUIRED_PACK_IDS,
+  getPackDisplayLabel,
+} from "../../frontend/src/remote/layer-pack-display-names.js";
+
+describe("layer-pack-display-names (contract)", () => {
+  test("REQUIRED_PACK_IDS lists known packs", () => {
+    expect(REQUIRED_PACK_IDS).toEqual([
+      "october_7th",
+      "projector_base",
+      "curated",
+    ]);
+  });
+
+  for (const packId of REQUIRED_PACK_IDS) {
+    if (packId === "curated") {
+      test("curated: no static pack label; layer title is t(curatedGroupLabel) from remote-locale", () => {
+        expect(getPackDisplayLabel("curated", "he")).toBeNull();
+        expect(getPackDisplayLabel("curated", "en")).toBeNull();
+      });
+      continue;
+    }
+    test(`${packId} has non-empty he/en labels`, () => {
+      const he = getPackDisplayLabel(packId, "he");
+      const en = getPackDisplayLabel(packId, "en");
+      expect(he).toBeTruthy();
+      expect(String(he).trim().length).toBeGreaterThan(0);
+      expect(en).toBeTruthy();
+      expect(String(en).trim().length).toBeGreaterThan(0);
+    });
+  }
+});

--- a/otef-interactive/tests/remote/layer-pack-labels-contract.test.js
+++ b/otef-interactive/tests/remote/layer-pack-labels-contract.test.js
@@ -2,13 +2,29 @@ import { describe, expect, test } from "vitest";
 import {
   REQUIRED_PACK_IDS,
   getPackDisplayLabel,
+  normalizePackId,
 } from "../../frontend/src/remote/layer-pack-display-names.js";
 
 describe("layer-pack-display-names (contract)", () => {
+  test("normalizePackId trims, lowercases, maps spaces and hyphens to underscore", () => {
+    expect(normalizePackId("  Map-3 Future  ")).toBe("map_3_future");
+    expect(normalizePackId("Municipality Transport")).toBe("municipality_transport");
+  });
+
+  test("getPackDisplayLabel matches PACK_LABELS after normalizePackId when direct key misses", () => {
+    expect(getPackDisplayLabel("map-3 future", "en")).toBe("Map 3 — future");
+    expect(getPackDisplayLabel("MUNICIPALITY transport", "he")).toBe("תחבורה מוניציפלית");
+  });
+
   test("REQUIRED_PACK_IDS lists known packs", () => {
     expect(REQUIRED_PACK_IDS).toEqual([
       "october_7th",
       "projector_base",
+      "map_3_future",
+      "curated_moresht_axis",
+      "future_development",
+      "municipality_transport",
+      "municpality_transport",
       "curated",
     ]);
   });

--- a/otef-interactive/tests/remote/layer-sheet-animation-controls.test.js
+++ b/otef-interactive/tests/remote/layer-sheet-animation-controls.test.js
@@ -40,13 +40,15 @@ describe('layer sheet animation controls', () => {
       animations: {},
     });
     expect(html).toContain('data-animation-toggle');
+    expect(html).toContain('layer-tile--anim');
 
     const html2 = renderLayerRow(makeNonAnimatableLayerRow(), {
       groupId: 'october_7th',
       animations: {},
     });
     expect(html2).not.toContain('data-animation-toggle');
-    expect(html2).toContain('anim-btn--absent');
+    expect(html2).not.toContain('layer-tile--anim');
+    expect(html2).not.toContain('anim-btn');
   });
 
   test('layer row animation chip is active when any row animation is enabled', () => {

--- a/otef-interactive/tests/remote/layer-sheet-animation-controls.test.js
+++ b/otef-interactive/tests/remote/layer-sheet-animation-controls.test.js
@@ -46,6 +46,7 @@ describe('layer sheet animation controls', () => {
       animations: {},
     });
     expect(html2).not.toContain('data-animation-toggle');
+    expect(html2).toContain('anim-btn--absent');
   });
 
   test('layer row animation chip is active when any row animation is enabled', () => {
@@ -81,7 +82,7 @@ describe('layer sheet animation controls', () => {
       },
     });
 
-    expect(html).toContain('animation-chip active mixed');
+    expect(html).toContain('class="anim-btn active mixed"');
   });
 });
 

--- a/otef-interactive/tests/remote/layer-sheet-animation-controls.test.js
+++ b/otef-interactive/tests/remote/layer-sheet-animation-controls.test.js
@@ -86,5 +86,77 @@ describe('layer sheet animation controls', () => {
 
     expect(html).toContain('class="anim-btn active mixed"');
   });
+
+  test('workshop pack row renders swatch when sanitized color metadata exists', () => {
+    const row = {
+      baseName: 'workshop-layer',
+      displayLabel: 'Workshop Layer',
+      fullLayerIds: ['curated_moresht_axis.foo'],
+      layers: [
+        {
+          id: 'foo',
+          name: 'Workshop Layer',
+          enabled: true,
+          display_color: '#aabbcc',
+        },
+      ],
+      enabled: true,
+    };
+    const html = renderLayerRow(row, { groupId: 'curated_moresht_axis', animations: {} });
+    expect(html).toContain('layer-tile__swatch');
+    expect(html).toContain('background-color:#aabbcc');
+  });
+
+  test('workshop pack row renders split-dot swatch for allowlisted submission color', () => {
+    const html = renderLayerRow(
+      {
+        baseName: 'styled',
+        displayLabel: 'Styled',
+        fullLayerIds: ['curated_moresht_axis.styled'],
+        layers: [
+          {
+            id: 'styled',
+            name: 'Styled',
+            enabled: true,
+            display_color: '#DC2626',
+          },
+        ],
+        enabled: true,
+      },
+      { groupId: 'curated_moresht_axis', animations: {} },
+    );
+    expect(html).toContain('layer-tile__swatch');
+    expect(html).toContain('curation-submission-swatch-dot');
+    expect(html).toContain('--swatch-primary:#DC2626');
+  });
+
+  test('workshop pack row omits swatch when no color source exists', () => {
+    const row = {
+      baseName: 'x',
+      displayLabel: 'X',
+      fullLayerIds: ['curated_moresht_axis.x'],
+      layers: [{ id: 'x', name: 'X', enabled: true }],
+      enabled: true,
+    };
+    const workshopNoColor = renderLayerRow(row, {
+      groupId: 'curated_moresht_axis',
+      animations: {},
+    });
+    expect(workshopNoColor).not.toContain('layer-tile__swatch');
+  });
+
+  test('non-workshop packs ignore submission color fields on tiles', () => {
+    const octoberWithColor = renderLayerRow(
+      {
+        baseName: 'y',
+        displayLabel: 'Y',
+        fullLayerIds: ['october_7th.y'],
+        layers: [{ id: 'y', name: 'Y', enabled: true, submissionColor: '#ff0000' }],
+        enabled: true,
+      },
+      { groupId: 'october_7th', animations: {} },
+    );
+    expect(octoberWithColor).not.toContain('layer-tile__swatch');
+  });
 });
 

--- a/otef-interactive/tests/remote/layer-sheet-root-contract.test.js
+++ b/otef-interactive/tests/remote/layer-sheet-root-contract.test.js
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Locks Task 6 default: HTML `#layerSheet` and constructor fallback stay aligned
+ * (LayerSheetController is not safe to instantiate in node without a DOM stub).
+ */
+test("LayerSheetController default rootId remains layerSheet", () => {
+  const src = fs.readFileSync(
+    path.resolve(__dirname, "../../frontend/src/remote/layer-sheet-controller.js"),
+    "utf8",
+  );
+  expect(src).toMatch(/options\.rootId\s*\|\|\s*["']layerSheet["']/);
+});

--- a/otef-interactive/tests/remote/remote-control-refresh-invariants.test.js
+++ b/otef-interactive/tests/remote/remote-control-refresh-invariants.test.js
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "vitest";
+import { shouldReapplyDpadAfterFullControlRefresh } from "../../frontend/src/remote/remote-control-refresh-invariants.js";
+
+describe("remote control refresh invariants", () => {
+  test("re-applies dpad lock only while joystick is the active control", () => {
+    expect(shouldReapplyDpadAfterFullControlRefresh(null)).toBe(false);
+    expect(shouldReapplyDpadAfterFullControlRefresh("dpad")).toBe(false);
+    expect(shouldReapplyDpadAfterFullControlRefresh("joystick")).toBe(true);
+  });
+});

--- a/otef-interactive/tests/remote/remote-locale.test.js
+++ b/otef-interactive/tests/remote/remote-locale.test.js
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+function installLocaleTestEnv(storeInit = {}) {
+  const store = { ...storeInit };
+  const ls = {
+    getItem: (k) => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
+    setItem: (k, v) => {
+      store[k] = String(v);
+    },
+    removeItem: (k) => {
+      delete store[k];
+    },
+  };
+  const root = {
+    setAttribute: vi.fn(function (name, value) {
+      this[name] = value;
+    }),
+    getAttribute: vi.fn(function (name) {
+      return this[name] ?? null;
+    }),
+  };
+  const doc = {
+    documentElement: root,
+    querySelectorAll: () => [],
+    get title() {
+      return this._title ?? "";
+    },
+    set title(v) {
+      this._title = v;
+    },
+  };
+  vi.stubGlobal("localStorage", ls);
+  vi.stubGlobal("document", doc);
+  vi.stubGlobal("window", {
+    dispatchEvent: vi.fn(),
+  });
+  return { store, root, doc };
+}
+
+describe("remote-locale", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("setLocale(en) sets LTR and en on document root", async () => {
+    installLocaleTestEnv();
+    const { setLocale, LOCALE_STORAGE_KEY, LOCALE_EVENT } = await import(
+      "../../frontend/src/remote/remote-locale.js"
+    );
+    expect(LOCALE_EVENT).toBe("otef:locale");
+    setLocale("en", { force: true });
+    const { document } = globalThis;
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith("dir", "ltr");
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith("lang", "en");
+    expect(globalThis.localStorage.getItem(LOCALE_STORAGE_KEY)).toBe("en");
+  });
+
+  test("setLocale(he) sets RTL and he on document root", async () => {
+    installLocaleTestEnv();
+    const { setLocale } = await import("../../frontend/src/remote/remote-locale.js");
+    setLocale("he", { force: true });
+    const { document } = globalThis;
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith("dir", "rtl");
+    expect(document.documentElement.setAttribute).toHaveBeenCalledWith("lang", "he");
+  });
+
+  test("initLocale reads persisted value from localStorage", async () => {
+    const key = "otef.remote.locale";
+    const preset = { [key]: "en" };
+    installLocaleTestEnv(preset);
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    installLocaleTestEnv(preset);
+    const { initLocale, getLocale, LOCALE_STORAGE_KEY } = await import(
+      "../../frontend/src/remote/remote-locale.js"
+    );
+    expect(LOCALE_STORAGE_KEY).toBe(key);
+    initLocale();
+    expect(getLocale()).toBe("en");
+  });
+
+  test("t() returns the correct string for the active locale", async () => {
+    installLocaleTestEnv();
+    const { t, setLocale } = await import("../../frontend/src/remote/remote-locale.js");
+    setLocale("he", { force: true });
+    expect(t("navLayers")).toBe("שכבות");
+    setLocale("en", { force: true });
+    expect(t("navLayers")).toBe("Layers");
+  });
+
+  test("t(curatedGroupLabel) localizes the curated pack fallback title", async () => {
+    installLocaleTestEnv();
+    const { t, setLocale } = await import("../../frontend/src/remote/remote-locale.js");
+    setLocale("he", { force: true });
+    expect(t("curatedGroupLabel")).toBe("אסופה");
+    setLocale("en", { force: true });
+    expect(t("curatedGroupLabel")).toBe("Curated");
+  });
+
+  test("setLocale dispatches otef:locale with detail.locale after apply", async () => {
+    installLocaleTestEnv();
+    const { setLocale, LOCALE_EVENT } = await import(
+      "../../frontend/src/remote/remote-locale.js"
+    );
+    setLocale("en", { force: true });
+    expect(globalThis.window.dispatchEvent).toHaveBeenCalled();
+    const ev = globalThis.window.dispatchEvent.mock.calls.at(-1)?.[0];
+    expect(ev).toBeDefined();
+    expect(ev.type).toBe(LOCALE_EVENT);
+    expect(ev.detail).toEqual({ locale: "en" });
+  });
+
+  test("initLocale dispatches otef:locale when storage matches in-memory default", async () => {
+    installLocaleTestEnv();
+    const { initLocale, LOCALE_EVENT } = await import(
+      "../../frontend/src/remote/remote-locale.js"
+    );
+    initLocale();
+    const ev = globalThis.window.dispatchEvent.mock.calls.at(-1)?.[0];
+    expect(ev?.type).toBe(LOCALE_EVENT);
+    expect(ev?.detail?.locale).toBe("he");
+  });
+});

--- a/otef-interactive/tests/remote/remote-locale.test.js
+++ b/otef-interactive/tests/remote/remote-locale.test.js
@@ -22,6 +22,7 @@ function installLocaleTestEnv(storeInit = {}) {
   const doc = {
     documentElement: root,
     querySelectorAll: () => [],
+    querySelector: () => null,
     get title() {
       return this._title ?? "";
     },
@@ -33,6 +34,7 @@ function installLocaleTestEnv(storeInit = {}) {
   vi.stubGlobal("document", doc);
   vi.stubGlobal("window", {
     dispatchEvent: vi.fn(),
+    addEventListener: vi.fn(),
   });
   return { store, root, doc };
 }
@@ -92,6 +94,33 @@ describe("remote-locale", () => {
     expect(t("navLayers")).toBe("Layers");
   });
 
+  test("curationSubmissionsRefreshTitle and curationSubmissionsRefreshAria exist in t() for both locales", async () => {
+    installLocaleTestEnv();
+    const { t, setLocale } = await import("../../frontend/src/remote/remote-locale.js");
+    setLocale("he", { force: true });
+    expect(t("curationSubmissionsRefreshTitle")).toBe("רענון רשימת הגשות");
+    expect(t("curationSubmissionsRefreshAria")).toBe("רענון רשימת ההגשות");
+    setLocale("en", { force: true });
+    expect(t("curationSubmissionsRefreshTitle")).toBe("Refresh submissions list");
+    expect(t("curationSubmissionsRefreshAria")).toBe("Refresh submissions list");
+  });
+
+  test("layer pack strip + layer animation aria keys resolve for both locales", async () => {
+    installLocaleTestEnv();
+    const { t, setLocale } = await import("../../frontend/src/remote/remote-locale.js");
+    const keys = [
+      "layersPackStripLabel",
+      "layersPackActiveCount",
+      "ariaLayersPackStrip",
+      "ariaLayerAnimationToggle",
+    ];
+    setLocale("he", { force: true });
+    const heOk = keys.every((k) => typeof t(k) === "string" && t(k) !== k);
+    setLocale("en", { force: true });
+    const enOk = keys.every((k) => typeof t(k) === "string" && t(k) !== k);
+    expect({ he: heOk, en: enOk }).toEqual({ he: true, en: true });
+  });
+
   test("t(curatedGroupLabel) localizes the curated pack fallback title", async () => {
     installLocaleTestEnv();
     const { t, setLocale } = await import("../../frontend/src/remote/remote-locale.js");
@@ -123,5 +152,23 @@ describe("remote-locale", () => {
     const ev = globalThis.window.dispatchEvent.mock.calls.at(-1)?.[0];
     expect(ev?.type).toBe(LOCALE_EVENT);
     expect(ev?.detail?.locale).toBe("he");
+  });
+
+  test("initLocale registers storage listener at most once", async () => {
+    installLocaleTestEnv();
+    const { initLocale, LOCALE_STORAGE_KEY, setLocale, getLocale } = await import(
+      "../../frontend/src/remote/remote-locale.js"
+    );
+    initLocale();
+    initLocale();
+    expect(globalThis.window.addEventListener).toHaveBeenCalled();
+    const storageCalls = globalThis.window.addEventListener.mock.calls.filter(
+      (c) => c[0] === "storage",
+    );
+    expect(storageCalls.length).toBe(1);
+    const onStorage = storageCalls[0][1];
+    setLocale("he", { force: true });
+    onStorage({ key: LOCALE_STORAGE_KEY, newValue: "en" });
+    expect(getLocale()).toBe("en");
   });
 });

--- a/otef-interactive/tests/remote/remote-locale.test.js
+++ b/otef-interactive/tests/remote/remote-locale.test.js
@@ -23,6 +23,7 @@ function installLocaleTestEnv(storeInit = {}) {
     documentElement: root,
     querySelectorAll: () => [],
     querySelector: () => null,
+    getElementById: () => null,
     get title() {
       return this._title ?? "";
     },
@@ -70,6 +71,51 @@ describe("remote-locale", () => {
     expect(document.documentElement.setAttribute).toHaveBeenCalledWith("lang", "he");
   });
 
+  test("applyRemoteChromeI18n sets curationSubmissionSearch dir from locale when present", async () => {
+    const searchEl = { setAttribute: vi.fn() };
+    const store = {};
+    const ls = {
+      getItem: (k) => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
+      setItem: (k, v) => {
+        store[k] = String(v);
+      },
+      removeItem: (k) => {
+        delete store[k];
+      },
+    };
+    const root = {
+      setAttribute: vi.fn(function (name, value) {
+        this[name] = value;
+      }),
+      getAttribute: vi.fn(function (name) {
+        return this[name] ?? null;
+      }),
+    };
+    const doc = {
+      documentElement: root,
+      querySelectorAll: () => [],
+      querySelector: () => null,
+      getElementById: vi.fn((id) => (id === "curationSubmissionSearch" ? searchEl : null)),
+      get title() {
+        return this._title ?? "";
+      },
+      set title(v) {
+        this._title = v;
+      },
+    };
+    vi.stubGlobal("localStorage", ls);
+    vi.stubGlobal("document", doc);
+    vi.stubGlobal("window", {
+      dispatchEvent: vi.fn(),
+      addEventListener: vi.fn(),
+    });
+    const { setLocale } = await import("../../frontend/src/remote/remote-locale.js");
+    setLocale("en", { force: true });
+    expect(searchEl.setAttribute).toHaveBeenCalledWith("dir", "ltr");
+    setLocale("he", { force: true });
+    expect(searchEl.setAttribute).toHaveBeenCalledWith("dir", "rtl");
+  });
+
   test("initLocale reads persisted value from localStorage", async () => {
     const key = "otef.remote.locale";
     const preset = { [key]: "en" };
@@ -105,13 +151,11 @@ describe("remote-locale", () => {
     expect(t("curationSubmissionsRefreshAria")).toBe("Refresh submissions list");
   });
 
-  test("layer pack strip + layer animation aria keys resolve for both locales", async () => {
+  test("layer pack counts + layer animation aria keys resolve for both locales", async () => {
     installLocaleTestEnv();
     const { t, setLocale } = await import("../../frontend/src/remote/remote-locale.js");
     const keys = [
-      "layersPackStripLabel",
       "layersPackActiveCount",
-      "ariaLayersPackStrip",
       "ariaLayerAnimationToggle",
     ];
     setLocale("he", { force: true });

--- a/otef-interactive/tests/remote/remote-tab-panels-hidden-contract.test.js
+++ b/otef-interactive/tests/remote/remote-tab-panels-hidden-contract.test.js
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Regression: `.remote-tab-panel { display:flex }` must not keep `[hidden]` panels
+ * in the flex layout (UA [hidden] loses to author rules of equal-ish specificity).
+ */
+test("remote-styles: hidden tab panels are display:none (out of layout)", () => {
+  const css = fs.readFileSync(
+    path.resolve(__dirname, "../../frontend/css/remote-styles.css"),
+    "utf8",
+  );
+  expect(css).toMatch(/\.remote-tab-panel\[hidden\]\s*\{[^}]*display:\s*none/s);
+});

--- a/otef-interactive/tests/shared/curated-supabase-heartbeat.test.js
+++ b/otef-interactive/tests/shared/curated-supabase-heartbeat.test.js
@@ -1,13 +1,61 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { startCuratedSupabaseHeartbeat } from "../../frontend/src/shared/curated-supabase-heartbeat.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 describe("startCuratedSupabaseHeartbeat", () => {
+  /** @type {typeof import("../../frontend/src/shared/curated-supabase-heartbeat.js").startCuratedSupabaseHeartbeat} */
+  let startCuratedSupabaseHeartbeat;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ startCuratedSupabaseHeartbeat } = await import(
+      "../../frontend/src/shared/curated-supabase-heartbeat.js"
+    ));
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
+  /** Top-level (non-embed) page: no embed query, not in a nested frame. */
+  function stubTopLevelWindow() {
+    const topRef = {};
+    return {
+      current: {
+        location: { search: "" },
+        self: topRef,
+        top: topRef,
+      },
+    };
+  }
+
+  it("does not poll when loaded as embedded curation (?embed=1 in iframe)", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const prevWindow = globalThis.window;
+    globalThis.window = {
+      location: { search: "?embed=1" },
+      self: {},
+      top: {},
+    };
+    let stop;
+    try {
+      stop = startCuratedSupabaseHeartbeat({
+        table: "otef",
+        intervalMs: 60_000,
+        onUpdated: vi.fn(),
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      if (stop) stop();
+      globalThis.window = prevWindow;
+    }
+  });
+
   it("requests pull-from-supabase and invokes onUpdated when updated is 1", async () => {
+    const stub = stubTopLevelWindow();
+    const prevWindow = globalThis.window;
+    globalThis.window = stub.current;
+
     const onUpdated = vi.fn();
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -20,24 +68,32 @@ describe("startCuratedSupabaseHeartbeat", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const stop = startCuratedSupabaseHeartbeat({
-      table: "otef",
-      intervalMs: 60_000,
-      onUpdated,
-    });
+    let stop;
+    try {
+      stop = startCuratedSupabaseHeartbeat({
+        table: "otef",
+        intervalMs: 60_000,
+        onUpdated,
+      });
 
-    await vi.waitFor(() => expect(onUpdated).toHaveBeenCalledTimes(1), {
-      timeout: 3000,
-    });
+      await vi.waitFor(() => expect(onUpdated).toHaveBeenCalledTimes(1), {
+        timeout: 3000,
+      });
 
-    expect(fetchMock).toHaveBeenCalled();
-    const url = String(fetchMock.mock.calls[0][0]);
-    expect(url).toContain("pull-from-supabase");
-
-    stop();
+      expect(fetchMock).toHaveBeenCalled();
+      const url = String(fetchMock.mock.calls[0][0]);
+      expect(url).toContain("pull-from-supabase");
+    } finally {
+      if (stop) stop();
+      globalThis.window = prevWindow;
+    }
   });
 
   it("merges listeners: one pull notifies every registered onUpdated", async () => {
+    const stub = stubTopLevelWindow();
+    const prevWindow = globalThis.window;
+    globalThis.window = stub.current;
+
     const onA = vi.fn();
     const onB = vi.fn();
     const fetchMock = vi.fn().mockResolvedValue({
@@ -51,28 +107,33 @@ describe("startCuratedSupabaseHeartbeat", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const stopA = startCuratedSupabaseHeartbeat({
-      table: "otef",
-      intervalMs: 60_000,
-      onUpdated: onA,
-    });
-    const stopB = startCuratedSupabaseHeartbeat({
-      table: "otef",
-      intervalMs: 60_000,
-      onUpdated: onB,
-    });
+    let stopA;
+    let stopB;
+    try {
+      stopA = startCuratedSupabaseHeartbeat({
+        table: "otef",
+        intervalMs: 60_000,
+        onUpdated: onA,
+      });
+      stopB = startCuratedSupabaseHeartbeat({
+        table: "otef",
+        intervalMs: 60_000,
+        onUpdated: onB,
+      });
 
-    await vi.waitFor(
-      () => {
-        expect(onA).toHaveBeenCalledTimes(1);
-        expect(onB).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 3000 },
-    );
+      await vi.waitFor(
+        () => {
+          expect(onA).toHaveBeenCalledTimes(1);
+          expect(onB).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 3000 },
+      );
 
-    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(1);
-
-    stopA();
-    stopB();
+      expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      if (stopA) stopA();
+      if (stopB) stopB();
+      globalThis.window = prevWindow;
+    }
   });
 });

--- a/otef-interactive/tests/shared/layer-name-utils.test.js
+++ b/otef-interactive/tests/shared/layer-name-utils.test.js
@@ -44,11 +44,62 @@ describe("getLayerDisplayLabel", () => {
     ).toBe("Infiltration into a community — axis");
   });
 
+  test("resolves runtime manifest id with hyphen (october_7th pack)", () => {
+    expect(
+      getLayerDisplayLabel(
+        "october_7th.אזור_הרס-אזור",
+        "en",
+        "אזור_הרס-אזור",
+        ["october_7th.אזור_הרס-אזור"],
+      ),
+    ).toBe("Destruction — area");
+  });
+
   test("falls back to formatLayerLabelForDisplay when id unknown", () => {
     expect(
       getLayerDisplayLabel("unknown_pack.layer", "he", "foo_bar-baz", [
         "unknown_pack.layer",
       ]),
     ).toBe("foo bar baz");
+  });
+
+  test("glossary en for GIS pack layer tiles (land_use, greens, future dev, muni transport)", () => {
+    expect(
+      getLayerDisplayLabel("land_use.מגורים", "en", "מגורים", ["land_use.מגורים"]),
+    ).toBe("Residential");
+    expect(
+      getLayerDisplayLabel("greens.גן_לאומי", "en", "גן לאומי", [
+        "greens.גן_לאומי",
+      ]),
+    ).toBe("National park");
+    expect(
+      getLayerDisplayLabel("future_development.מימושים", "en", "מימושים", [
+        "future_development.מימושים",
+      ]),
+    ).toBe("Zoning build-out");
+    expect(
+      getLayerDisplayLabel("muniplicity_transport.שבילי_אופניים", "en", "שבילי אופניים", [
+        "muniplicity_transport.שבילי_אופניים",
+      ]),
+    ).toBe("Bicycle paths");
+  });
+
+  test("glossary en for runtime ids (muni outline, road exit, land_use fire zone underscore)", () => {
+    expect(
+      getLayerDisplayLabel(
+        "muniplicity_transport.מועצות_אזוריות_מתאר",
+        "en",
+        "מועצות אזוריות מתאר",
+        ["muniplicity_transport.מועצות_אזוריות_מתאר"],
+      ),
+    ).toBe("Regional councils (cartographic outline)");
+    expect(
+      getLayerDisplayLabel("future_development.יציאה_כביש", "en", "יציאה כביש", [
+        "future_development.יציאה_כביש",
+      ]),
+    ).toBe("Road exit");
+    expect(
+      getLayerDisplayLabel("land_use.שטחי_אש_", "en", "שטחי אש", ["land_use.שטחי_אש_"]),
+    ).toBe("Fire zones");
   });
 });

--- a/otef-interactive/tests/shared/layer-name-utils.test.js
+++ b/otef-interactive/tests/shared/layer-name-utils.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { formatLayerLabelForDisplay } from "../../frontend/src/shared/layer-name-utils.js";
+import { getLayerDisplayLabel } from "../../frontend/src/shared/layer-display-glossary.js";
 
 describe("formatLayerLabelForDisplay", () => {
   test("maps underscore and hyphen runs to single spaces", () => {
@@ -15,5 +16,39 @@ describe("formatLayerLabelForDisplay", () => {
   test("returns empty for non-strings", () => {
     expect(formatLayerLabelForDisplay(null)).toBe("");
     expect(formatLayerLabelForDisplay(undefined)).toBe("");
+  });
+});
+
+describe("getLayerDisplayLabel", () => {
+  test("uses glossary for known full id and locale he", () => {
+    const s = getLayerDisplayLabel("projector_base.sea", "he", "sea", [
+      "projector_base.sea",
+    ]);
+    expect(s).toBe("ים");
+  });
+
+  test("uses glossary for en", () => {
+    expect(
+      getLayerDisplayLabel("map_3_future.greens", "en", "greens", [
+        "map_3_future.greens",
+      ]),
+    ).toBe("Greens");
+  });
+
+  test("tries fullLayerIds in order; first match wins", () => {
+    expect(
+      getLayerDisplayLabel("october_7th.חדירה_לישוב-ציר", "en", "חדירה לישוב", [
+        "october_7th.חדירה_לישוב-ציר",
+        "october_7th.חדירה_לישוב-נקודה",
+      ]),
+    ).toBe("Infiltration into a community — axis");
+  });
+
+  test("falls back to formatLayerLabelForDisplay when id unknown", () => {
+    expect(
+      getLayerDisplayLabel("unknown_pack.layer", "he", "foo_bar-baz", [
+        "unknown_pack.layer",
+      ]),
+    ).toBe("foo bar baz");
   });
 });

--- a/otef-interactive/tests/shared/layer-name-utils.test.js
+++ b/otef-interactive/tests/shared/layer-name-utils.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+import { formatLayerLabelForDisplay } from "../../frontend/src/shared/layer-name-utils.js";
+
+describe("formatLayerLabelForDisplay", () => {
+  test("maps underscore and hyphen runs to single spaces", () => {
+    expect(formatLayerLabelForDisplay("אירוע_נקודתי-רציחה_חטיפה")).toBe(
+      "אירוע נקודתי רציחה חטיפה",
+    );
+  });
+
+  test("collapses whitespace", () => {
+    expect(formatLayerLabelForDisplay("  a__b  -c  ")).toBe("a b c");
+  });
+
+  test("returns empty for non-strings", () => {
+    expect(formatLayerLabelForDisplay(null)).toBe("");
+    expect(formatLayerLabelForDisplay(undefined)).toBe("");
+  });
+});

--- a/otef-interactive/tests/shared/layer-state-helper.test.js
+++ b/otef-interactive/tests/shared/layer-state-helper.test.js
@@ -107,7 +107,32 @@ describe("layer-state-helper: curated group display names", () => {
     delete global.layerRegistry;
   });
 
-  test("canonicalizes single curated group to Moreshet Axis name/id", () => {
+  test("preserves API color fields on context-only workshop layers for UI swatches", () => {
+    global.OTEFDataContext = {
+      getLayerGroups: () => [
+        {
+          id: "curated_x",
+          enabled: true,
+          layers: [
+            {
+              id: "7",
+              displayName: "Proposal",
+              enabled: true,
+              display_color: "#c0ffee",
+            },
+          ],
+        },
+      ],
+    };
+    delete global.layerRegistry;
+
+    const groups = getEffectiveLayerGroups();
+    expect(
+      groups[0].layers.some((l) => l && l.display_color === "#c0ffee"),
+    ).toBe(true);
+  });
+
+  test("canonicalizes single curated group to Workshop name/id", () => {
     global.OTEFDataContext = {
       getLayerGroups: () => [
         {
@@ -124,10 +149,10 @@ describe("layer-state-helper: curated group display names", () => {
     const groups = getEffectiveLayerGroups();
     expect(groups).toHaveLength(1);
     expect(groups[0].id).toBe("curated_moresht_axis");
-    expect(groups[0].name).toBe("Moreshet Axis");
+    expect(groups[0].name).toBe("Workshop");
   });
 
-  test("canonicalizes curated slug-only group to Moreshet Axis", () => {
+  test("canonicalizes curated slug-only group to Workshop", () => {
     global.OTEFDataContext = {
       getLayerGroups: () => [
         {
@@ -142,10 +167,10 @@ describe("layer-state-helper: curated group display names", () => {
     const groups = getEffectiveLayerGroups();
     expect(groups).toHaveLength(1);
     expect(groups[0].id).toBe("curated_moresht_axis");
-    expect(groups[0].name).toBe("Moreshet Axis");
+    expect(groups[0].name).toBe("Workshop");
   });
 
-  test("coalesces multiple curated project groups into one Moreshet Axis group", () => {
+  test("coalesces multiple curated project groups into one Workshop group", () => {
     global.OTEFDataContext = {
       getLayerGroups: () => [
         {
@@ -167,7 +192,7 @@ describe("layer-state-helper: curated group display names", () => {
     const groups = getEffectiveLayerGroups();
     expect(groups).toHaveLength(1);
     expect(groups[0].id).toBe("curated_moresht_axis");
-    expect(groups[0].name).toBe("Moreshet Axis");
+    expect(groups[0].name).toBe("Workshop");
     expect(groups[0].layers.map((l) => l.id)).toEqual(["10", "11", "pink_line_parking"]);
   });
 


### PR DESCRIPTION
## Summary
- Rebuilt the remote controller shell into a mobile-first tabbed interface with dedicated Navigation, Layers, and Curation surfaces, updated styling tokens, and improved controller layout density.
- Added full remote locale support (Hebrew/English) with runtime `lang/dir` switching, localized remote chrome copy, and consistent display naming for layer packs and layer titles.
- Refactored Layers UX to a focused-pack workflow with a horizontal pack strip, bulk visibility control, compact layer tiles, clearer on/off/primary visual states, and animation controls aligned to tile interactions.
- Embedded curation directly in the remote via iframe, aligned embedded chrome behavior, improved published-layer metadata rendering, and fixed submission badge parity so list tagging matches submission semantics.
- Improved workshop layer affordances by wiring display-name updates and submission-color swatches into layer tiles, plus related CSS polish for clearer interaction feedback.